### PR TITLE
feat: URL sharing for custom photo grids

### DIFF
--- a/js/photo-grid.js
+++ b/js/photo-grid.js
@@ -11,7 +11,10 @@
     const state = {
         currentTheme: '',
         gridImages: new Array(81).fill(null),
-        selectedCell: null
+        selectedCell: null,
+        gridTexts: new Array(81).fill(null),
+        gridComplete: false,
+        shareId: null
     };
     
     // DOM要素
@@ -43,7 +46,16 @@
             
             const placeholder = document.createElement('div');
             placeholder.className = 'grid-placeholder';
-            placeholder.textContent = '+';
+            
+            // テキストまたは+記号を表示
+            if (state.gridTexts[i]) {
+                placeholder.textContent = state.gridTexts[i];
+                placeholder.style.fontSize = '14px';
+                placeholder.style.padding = '5px';
+            } else {
+                placeholder.textContent = '+';
+            }
+            
             gridItem.appendChild(placeholder);
             
             gridItem.addEventListener('click', () => handleCellClick(i));
@@ -53,8 +65,15 @@
     
     // セルクリックハンドラー
     function handleCellClick(index) {
-        state.selectedCell = index;
-        elements.uploadModal.classList.add('active');
+        // 共有されたグリッドの場合のみ写真アップロードを許可
+        if (state.shareId && state.gridTexts[index] && !state.gridImages[index]) {
+            state.selectedCell = index;
+            elements.uploadModal.classList.add('active');
+        } else if (!state.shareId) {
+            // 通常モードでは常に写真アップロード可能
+            state.selectedCell = index;
+            elements.uploadModal.classList.add('active');
+        }
     }
     
     // テーマ適用
@@ -71,6 +90,11 @@
         
         // テーマに基づいて背景グラデーションを変更
         updateThemeColors();
+        
+        // テーマに基づいてグリッドにテキストを配置
+        if (!state.shareId) {
+            generateGridTexts(theme);
+        }
     }
     
     // テーマカラーの更新
@@ -92,6 +116,28 @@
         return hash;
     }
     
+    // グリッドテキストの生成
+    function generateGridTexts(theme) {
+        // テーマに基づいてテキストラベルを生成
+        const labels = [];
+        const words = theme.split(/\s+/);
+        const baseWords = ['写真', '思い出', '瞬間', '景色', '風景', '美しさ', '魅力', '感動'];
+        
+        // テーマの単語とベース単語を組み合わせてラベルを生成
+        for (let i = 0; i < 81; i++) {
+            if (Math.random() < 0.3) { // 30%の確率でテキストを配置
+                const wordIndex = Math.floor(Math.random() * words.length);
+                const baseIndex = Math.floor(Math.random() * baseWords.length);
+                labels.push(`${words[wordIndex] || theme}の${baseWords[baseIndex]}`);
+            } else {
+                labels.push(null);
+            }
+        }
+        
+        state.gridTexts = labels;
+        updateGridDisplay();
+    }
+    
     // サジェスチョンチップのクリック
     function handleSuggestionClick(e) {
         const theme = e.target.dataset.theme;
@@ -104,6 +150,9 @@
         if (!confirm('すべての写真を削除しますか？')) return;
         
         state.gridImages = new Array(81).fill(null);
+        state.gridTexts = new Array(81).fill(null);
+        state.gridComplete = false;
+        state.shareId = null;
         updateGridDisplay();
         showToast('グリッドをクリアしました', 'info');
     }
@@ -145,10 +194,22 @@
         
         gridItems.forEach((item, index) => {
             const image = state.gridImages[index];
+            const text = state.gridTexts[index];
             
             if (image) {
                 item.classList.remove('empty');
                 item.innerHTML = `<img src="${image}" alt="Grid image ${index + 1}">`;
+            } else if (text) {
+                item.classList.add('empty');
+                const placeholder = document.createElement('div');
+                placeholder.className = 'grid-placeholder';
+                placeholder.textContent = text;
+                placeholder.style.fontSize = '14px';
+                placeholder.style.padding = '5px';
+                placeholder.style.whiteSpace = 'normal';
+                placeholder.style.lineHeight = '1.2';
+                item.innerHTML = '';
+                item.appendChild(placeholder);
             } else {
                 item.classList.add('empty');
                 item.innerHTML = '<div class="grid-placeholder">+</div>';
@@ -170,6 +231,11 @@
                 updateGridDisplay();
                 closeModal();
                 showToast('画像をアップロードしました', 'success');
+                
+                // 共有グリッドで全ての写真が追加されたかチェック
+                if (state.shareId) {
+                    checkGridCompletion();
+                }
             }
         };
         reader.readAsDataURL(file);
@@ -188,10 +254,21 @@
             return;
         }
         
+        // グリッドデータを準備
+        const gridData = {
+            theme: state.currentTheme,
+            texts: state.gridTexts.filter(t => t !== null),
+            timestamp: Date.now()
+        };
+        
+        // Base64エンコード
+        const encodedData = btoa(encodeURIComponent(JSON.stringify(gridData)));
+        const shareUrl = `${window.location.origin}${window.location.pathname}?grid=${encodedData}`;
+        
         const shareData = {
             title: `GridMe - ${state.currentTheme}`,
             text: `「${state.currentTheme}」のフォトグリッドを作成しました！`,
-            url: window.location.href
+            url: shareUrl
         };
         
         try {
@@ -200,7 +277,7 @@
                 showToast('共有しました', 'success');
             } else {
                 // フォールバック: URLをクリップボードにコピー
-                await navigator.clipboard.writeText(window.location.href);
+                await navigator.clipboard.writeText(shareUrl);
                 showToast('URLをコピーしました', 'success');
             }
         } catch (err) {
@@ -229,27 +306,68 @@
         });
     }
     
+    // グリッド完成チェック
+    function checkGridCompletion() {
+        // テキストがあるセルが全て画像で埋まっているかチェック
+        let isComplete = true;
+        for (let i = 0; i < 81; i++) {
+            if (state.gridTexts[i] && !state.gridImages[i]) {
+                isComplete = false;
+                break;
+            }
+        }
+        
+        state.gridComplete = isComplete;
+        
+        if (isComplete) {
+            showToast('グリッドが完成しました！保存ボタンから保存してください。', 'success');
+        }
+    }
+    
     // 保存機能
     function saveGrid() {
         const gridData = {
             theme: state.currentTheme,
             images: state.gridImages,
-            timestamp: new Date().toISOString()
+            texts: state.gridTexts,
+            timestamp: new Date().toISOString(),
+            shareId: state.shareId
         };
         
-        localStorage.setItem('gridme-current', JSON.stringify(gridData));
-        showToast('グリッドを保存しました', 'success');
+        // 完成したグリッドを保存
+        if (state.gridComplete) {
+            const savedGrids = JSON.parse(localStorage.getItem('gridme-saved-grids') || '[]');
+            savedGrids.push(gridData);
+            localStorage.setItem('gridme-saved-grids', JSON.stringify(savedGrids));
+            
+            // 共有URLを生成
+            const shareUrl = generateShareableUrl(gridData);
+            showToast('グリッドを保存しました', 'success');
+            
+            // 共有ダイアログを表示
+            showShareDialog(shareUrl);
+        } else {
+            localStorage.setItem('gridme-current', JSON.stringify(gridData));
+            showToast('グリッドを保存しました', 'success');
+        }
     }
     
     // 保存データの読み込み
     function loadSavedGrid() {
-        const savedData = localStorage.getItem('gridme-current');
+        // URLパラメータをチェック
+        const urlParams = new URLSearchParams(window.location.search);
+        const gridParam = urlParams.get('grid');
+        const fullGridParam = urlParams.get('fullgrid');
         
-        if (savedData) {
+        if (fullGridParam) {
+            // 完成したグリッドの読み込み
             try {
-                const data = JSON.parse(savedData);
-                state.currentTheme = data.theme || '';
-                state.gridImages = data.images || new Array(81).fill(null);
+                const decodedData = JSON.parse(decodeURIComponent(atob(fullGridParam)));
+                state.currentTheme = decodedData.theme || '';
+                state.gridImages = decodedData.images || new Array(81).fill(null);
+                state.gridTexts = decodedData.texts || new Array(81).fill(null);
+                state.shareId = decodedData.timestamp;
+                state.gridComplete = true;
                 
                 if (state.currentTheme) {
                     elements.themeInput.value = state.currentTheme;
@@ -257,9 +375,65 @@
                     updateThemeColors();
                 }
                 
+                showToast('共有されたグリッドを表示しています', 'info');
                 updateGridDisplay();
             } catch (err) {
-                console.error('保存データの読み込みエラー:', err);
+                console.error('共有データの読み込みエラー:', err);
+                showToast('共有データの読み込みに失敗しました', 'error');
+            }
+        } else if (gridParam) {
+            // 共有URLからの読み込み
+            try {
+                const decodedData = JSON.parse(decodeURIComponent(atob(gridParam)));
+                state.currentTheme = decodedData.theme || '';
+                state.shareId = decodedData.timestamp;
+                
+                // テキストを配置
+                if (decodedData.texts && Array.isArray(decodedData.texts)) {
+                    let textIndex = 0;
+                    for (let i = 0; i < 81 && textIndex < decodedData.texts.length; i++) {
+                        if (Math.random() < 0.3) { // 元の確率と同じくらいでテキストを配置
+                            state.gridTexts[i] = decodedData.texts[textIndex];
+                            textIndex++;
+                        }
+                    }
+                }
+                
+                if (state.currentTheme) {
+                    elements.themeInput.value = state.currentTheme;
+                    elements.currentThemeDisplay.textContent = `フォトグリッド - ${state.currentTheme}`;
+                    updateThemeColors();
+                }
+                
+                // 共有モードであることを表示
+                showToast('共有されたグリッドを読み込みました。各セルをタップして写真を追加してください。', 'info');
+                
+                updateGridDisplay();
+            } catch (err) {
+                console.error('共有データの読み込みエラー:', err);
+                showToast('共有データの読み込みに失敗しました', 'error');
+            }
+        } else {
+            // ローカル保存データの読み込み
+            const savedData = localStorage.getItem('gridme-current');
+            
+            if (savedData) {
+                try {
+                    const data = JSON.parse(savedData);
+                    state.currentTheme = data.theme || '';
+                    state.gridImages = data.images || new Array(81).fill(null);
+                    state.gridTexts = data.texts || new Array(81).fill(null);
+                    
+                    if (state.currentTheme) {
+                        elements.themeInput.value = state.currentTheme;
+                        elements.currentThemeDisplay.textContent = `フォトグリッド - ${state.currentTheme}`;
+                        updateThemeColors();
+                    }
+                    
+                    updateGridDisplay();
+                } catch (err) {
+                    console.error('保存データの読み込みエラー:', err);
+                }
             }
         }
     }
@@ -329,6 +503,50 @@
                 closeModal();
             }
         });
+    }
+    
+    // 共有可能なURLを生成
+    function generateShareableUrl(gridData) {
+        const shareData = {
+            theme: gridData.theme,
+            images: gridData.images,
+            texts: gridData.texts,
+            timestamp: gridData.timestamp
+        };
+        
+        // Base64エンコード（画像付き）
+        const encodedData = btoa(encodeURIComponent(JSON.stringify(shareData)));
+        return `${window.location.origin}${window.location.pathname}?fullgrid=${encodedData}`;
+    }
+    
+    // 共有ダイアログを表示
+    function showShareDialog(shareUrl) {
+        // シンプルなモーダルを作成
+        const modal = document.createElement('div');
+        modal.className = 'modal active';
+        modal.innerHTML = `
+            <div class="modal-content card-glass">
+                <div class="modal-header">
+                    <h3>グリッドを共有</h3>
+                    <button class="btn-icon modal-close" onclick="this.closest('.modal').remove()">
+                        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <line x1="18" y1="6" x2="6" y2="18"/>
+                            <line x1="6" y1="6" x2="18" y2="18"/>
+                        </svg>
+                    </button>
+                </div>
+                <div class="modal-body">
+                    <p>完成したグリッドの共有URLです：</p>
+                    <div style="margin: 15px 0;">
+                        <input type="text" value="${shareUrl}" class="input" readonly style="width: 100%;">
+                    </div>
+                    <button class="btn-primary" onclick="navigator.clipboard.writeText('${shareUrl}').then(() => showToast('URLをコピーしました', 'success'))">
+                        URLをコピー
+                    </button>
+                </div>
+            </div>
+        `;
+        document.body.appendChild(modal);
     }
     
     // html2canvasライブラリの動的読み込み

--- a/styles/app.css
+++ b/styles/app.css
@@ -730,6 +730,10 @@ body {
 .grid-placeholder {
     color: var(--text-tertiary);
     font-size: var(--text-2xl);
+    text-align: center;
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+    hyphens: auto;
 }
 
 /* ===== アクションセクション ===== */


### PR DESCRIPTION
## Summary
- Add URL sharing functionality that allows users to share custom grids
- Recipients can add photos to text-labeled cells
- Completed grids can be saved and shared with photos

## Changes
- Modified `photo-grid.js` to support URL parameters and grid sharing
- Updated CSS for better text display in grid cells
- Added grid completion detection and share dialog

## Test Plan
1. Create a new grid with a theme
2. Click the share button to get a shareable URL
3. Open the URL in a new browser tab
4. Add photos to the text-labeled cells
5. Save the completed grid and share it

Closes #35

🤖 Generated with [Claude Code](https://claude.ai/code)