### PR TITLE
Issue #56: 枠

### DIFF
--- a/styles/app.css
+++ b/styles/app.css
@@ -719,7 +719,7 @@ body {
     max-width: 800px;
     width: 100%;
     margin: 0 auto;
-    background: var(--bg-secondary);
+    background: #000000;
     padding: var(--spacing-6);
     border-radius: var(--radius-xl);
     box-shadow: var(--shadow-xl);

--- a/styles/shared.css
+++ b/styles/shared.css
@@ -25,7 +25,7 @@
     gap: var(--spacing-4);
     max-width: 900px;
     margin: 0 auto var(--spacing-10);
-    background: var(--bg-secondary);
+    background: #000000;
     padding: var(--spacing-6);
     border-radius: var(--radius-xl);
     box-shadow: var(--shadow-xl);


### PR DESCRIPTION
This PR addresses issue #56

グリッドの枠外を黒く塗りつぶしました。

- theme-gridの背景色を#000000に変更
- photo-theme-gridの背景色を#000000に変更
- 写真やテキストが入る枠以外の部分が黒く塗りつぶされるように修正

Generated with [Claude Code](https://claude.ai/code)