### PR TITLE
fix: ダークモードでヘッダーの色を背景色と同じにする

### DIFF
--- a/styles/app.css
+++ b/styles/app.css
@@ -72,7 +72,7 @@ body {
 
 @media (prefers-color-scheme: dark) {
     .navbar {
-        background: rgba(9, 9, 11, 0.8);
+        background: var(--bg-primary);
     }
 }
 
@@ -561,7 +561,7 @@ body {
 
 @media (prefers-color-scheme: dark) {
     .app-header {
-        background: rgba(9, 9, 11, 0.9);
+        background: var(--bg-primary);
     }
 }
 


### PR DESCRIPTION
## Summary
ダークモード時のヘッダー色を背景色と同じにしました。

## Changes
- `.navbar`のダークモード背景色を`var(--bg-primary)`に変更
- `.app-header`のダークモード背景色を`var(--bg-primary)`に変更

Closes #63

🤖 Generated with [Claude Code](https://claude.ai/code)