### PR TITLE
fix: adjust text input colors for better contrast balance

### DIFF
--- a/styles/app.css
+++ b/styles/app.css
@@ -761,14 +761,14 @@ body {
     font-size: var(--text-sm);
     font-weight: var(--font-normal);
     transition: all var(--transition-base);
-    background: rgba(255, 255, 255, 0.3);
+    background: rgba(0, 0, 0, 0.08); /* More gray/visible in light mode */
     color: var(--text-secondary);
 }
 
 .section-title-input:focus {
     outline: none;
     box-shadow: none;
-    background: rgba(255, 255, 255, 0.5);
+    background: rgba(0, 0, 0, 0.12); /* Darker on focus */
 }
 
 /* セクションテーマ選択 */
@@ -779,7 +779,7 @@ body {
     padding: var(--spacing-2) var(--spacing-3);
     font-size: var(--text-sm);
     transition: all var(--transition-base);
-    background: var(--bg-primary);
+    background: var(--neutral-200); /* Changed to match input styling */
     color: var(--text-primary);
     cursor: pointer;
 }
@@ -787,7 +787,7 @@ body {
 .section-theme-select:focus {
     outline: none;
     border-color: var(--primary-solid);
-    box-shadow: 0 0 0 3px rgba(var(--primary-rgb), 0.1);
+    box-shadow: 0 0 0 3px rgba(255, 107, 53, 0.1);
 }
 
 /* セクションコンテンツ入力 */
@@ -798,7 +798,7 @@ body {
     padding: var(--spacing-2) var(--spacing-3);
     font-size: var(--text-sm);
     transition: all var(--transition-base);
-    background: var(--bg-primary);
+    background: var(--neutral-200); /* Changed to match input styling */
     color: var(--text-primary);
     resize: vertical;
     min-height: 80px;
@@ -808,7 +808,22 @@ body {
 .section-content-input:focus {
     outline: none;
     border-color: var(--primary-solid);
-    box-shadow: 0 0 0 3px rgba(var(--primary-rgb), 0.1);
+    box-shadow: 0 0 0 3px rgba(255, 107, 53, 0.1);
+}
+
+/* Dark mode styles for section inputs */
+@media (prefers-color-scheme: dark) {
+    .section-theme-select,
+    .section-content-input {
+        background: var(--neutral-900); /* Closer to background */
+        border-color: var(--neutral-800);
+    }
+    
+    .section-theme-select:focus,
+    .section-content-input:focus {
+        background: var(--neutral-800);
+        border-color: var(--primary-solid);
+    }
 }
 
 
@@ -868,12 +883,12 @@ body {
     }
     
     .section-title-input {
-        background: rgba(0, 0, 0, 0.2);
+        background: rgba(255, 255, 255, 0.03); /* Much closer to background, less prominent */
         color: var(--text-secondary);
     }
     
     .section-title-input:focus {
-        background: rgba(0, 0, 0, 0.3);
+        background: rgba(255, 255, 255, 0.05); /* Subtle increase on focus */
     }
     
 }

--- a/styles/components.css
+++ b/styles/components.css
@@ -179,7 +179,7 @@
 /* テキストインプット */
 .input {
   width: 100%;
-  background: var(--bg-secondary);
+  background: var(--neutral-200); /* Changed from bg-secondary to be more gray/prominent in light mode */
   border: 2px solid transparent;
   border-radius: var(--radius-md);
   padding: var(--spacing-3) var(--spacing-4);
@@ -199,10 +199,23 @@
   color: var(--text-tertiary);
 }
 
+/* Dark mode specific adjustments for inputs */
+@media (prefers-color-scheme: dark) {
+  .input {
+    background: var(--neutral-900); /* Closer to background color (--neutral-950) */
+    border: 1px solid var(--neutral-800); /* Subtle border for visibility */
+  }
+  
+  .input:focus {
+    background: var(--neutral-800); /* Slightly lighter on focus */
+    border-color: var(--primary-solid);
+  }
+}
+
 /* テキストエリア */
 .textarea {
   width: 100%;
-  background: var(--bg-secondary);
+  background: var(--neutral-200); /* Changed from bg-secondary to match input styling */
   border: 2px solid transparent;
   border-radius: var(--radius-md);
   padding: var(--spacing-3) var(--spacing-4);
@@ -218,6 +231,19 @@
   border-color: var(--primary-solid);
   background: var(--bg-primary);
   box-shadow: 0 0 0 4px rgba(255, 107, 53, 0.1);
+}
+
+/* Dark mode specific adjustments for textarea */
+@media (prefers-color-scheme: dark) {
+  .textarea {
+    background: var(--neutral-900); /* Closer to background color */
+    border: 1px solid var(--neutral-800); /* Subtle border for visibility */
+  }
+  
+  .textarea:focus {
+    background: var(--neutral-800); /* Slightly lighter on focus */
+    border-color: var(--primary-solid);
+  }
 }
 
 /* ===== バッジ ===== */


### PR DESCRIPTION
## Summary
- Adjusted text input colors for better visual balance in both light and dark modes
- Light mode: inputs are now more gray/prominent as requested
- Dark mode: inputs are closer to background color and less prominent

## Changes
- Updated `.input` and `.textarea` styles in components.css
- Updated section-specific input styles in app.css
- Added dark mode overrides for all input types

Resolves #64

🤖 Generated with [Claude Code](https://claude.ai/code)