### PR TITLE
fix: 共有ボタンとGridの間に間隔を追加

### DIFF
--- a/styles/app.css
+++ b/styles/app.css
@@ -708,6 +708,7 @@ body {
 
 /* ===== 共有ボタンコンテナ ===== */
 .share-button-container {
+    margin-top: var(--spacing-8);
     margin-bottom: var(--spacing-8);
 }
 


### PR DESCRIPTION
## Summary
- 共有ボタンとGridの間に適切な間隔を追加しました
- `.share-button-container`クラスに`margin-top: var(--spacing-8)`を追加

## Test plan
- ブラウザでページを開いて、共有ボタンとGridの間に適切な間隔があることを確認
- ライトモードとダークモードでデザインが正しく表示されることを確認

Closes #69

🤖 Generated with [Claude Code](https://claude.ai/code)