### PR TITLE
fix: テーマ候補チップの黒表示問題を修正

### DIFF
--- a/styles/app.css
+++ b/styles/app.css
@@ -911,6 +911,8 @@ body {
     min-width: 120px;
     height: 50px;
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+    /* フォールバック背景色を追加 */
+    background: var(--gradient-primary);
 }
 
 .theme-chip:hover {
@@ -923,16 +925,16 @@ body {
 }
 
 /* チップのカラフルな背景色 */
-.chip-color-1 { background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); }
-.chip-color-2 { background: linear-gradient(135deg, #f093fb 0%, #f5576c 100%); }
-.chip-color-3 { background: linear-gradient(135deg, #4facfe 0%, #00f2fe 100%); }
-.chip-color-4 { background: linear-gradient(135deg, #43e97b 0%, #38f9d7 100%); }
-.chip-color-5 { background: linear-gradient(135deg, #fa709a 0%, #fee140 100%); }
-.chip-color-6 { background: linear-gradient(135deg, #30cfd0 0%, #330867 100%); }
-.chip-color-7 { background: linear-gradient(135deg, #a8edea 0%, #fed6e3 100%); }
-.chip-color-8 { background: linear-gradient(135deg, #ffd89b 0%, #19547b 100%); }
-.chip-color-9 { background: linear-gradient(135deg, #ff9a9e 0%, #fecfef 100%); }
-.chip-color-10 { background: linear-gradient(135deg, #fbc2eb 0%, #a6c1ee 100%); }
+.chip-color-1 { background: linear-gradient(135deg, #667eea 0%, #764ba2 100%) !important; }
+.chip-color-2 { background: linear-gradient(135deg, #f093fb 0%, #f5576c 100%) !important; }
+.chip-color-3 { background: linear-gradient(135deg, #4facfe 0%, #00f2fe 100%) !important; }
+.chip-color-4 { background: linear-gradient(135deg, #43e97b 0%, #38f9d7 100%) !important; }
+.chip-color-5 { background: linear-gradient(135deg, #fa709a 0%, #fee140 100%) !important; }
+.chip-color-6 { background: linear-gradient(135deg, #30cfd0 0%, #330867 100%) !important; }
+.chip-color-7 { background: linear-gradient(135deg, #a8edea 0%, #fed6e3 100%) !important; }
+.chip-color-8 { background: linear-gradient(135deg, #ffd89b 0%, #19547b 100%) !important; }
+.chip-color-9 { background: linear-gradient(135deg, #ff9a9e 0%, #fecfef 100%) !important; }
+.chip-color-10 { background: linear-gradient(135deg, #fbc2eb 0%, #a6c1ee 100%) !important; }
 
 /* ダークモード対応 */
 @media (prefers-color-scheme: dark) {


### PR DESCRIPTION
## Summary
- テーマ候補チップが黒く表示される問題を修正
- フォールバック背景色を追加して常に表示されるように改善

Fixes #70

🤖 Generated with [Claude Code](https://claude.ai/code)