### PR TITLE
fix: テキストインプットの色をより控えめに調整

### DIFF
--- a/styles/components.css
+++ b/styles/components.css
@@ -179,7 +179,7 @@
 /* テキストインプット */
 .input {
   width: 100%;
-  background: var(--neutral-200); /* Changed from bg-secondary to be more gray/prominent in light mode */
+  background: var(--neutral-100); /* Lighter gray for more subtle appearance in light mode */
   border: 2px solid transparent;
   border-radius: var(--radius-md);
   padding: var(--spacing-3) var(--spacing-4);
@@ -202,12 +202,12 @@
 /* Dark mode specific adjustments for inputs */
 @media (prefers-color-scheme: dark) {
   .input {
-    background: var(--neutral-900); /* Closer to background color (--neutral-950) */
-    border: 1px solid var(--neutral-800); /* Subtle border for visibility */
+    background: var(--neutral-800); /* Lighter gray for more subtle appearance in dark mode */
+    border: 1px solid var(--neutral-700); /* Subtle border for visibility */
   }
   
   .input:focus {
-    background: var(--neutral-800); /* Slightly lighter on focus */
+    background: var(--neutral-700); /* Slightly lighter on focus */
     border-color: var(--primary-solid);
   }
 }
@@ -215,7 +215,7 @@
 /* テキストエリア */
 .textarea {
   width: 100%;
-  background: var(--neutral-200); /* Changed from bg-secondary to match input styling */
+  background: var(--neutral-100); /* Lighter gray for more subtle appearance in light mode */
   border: 2px solid transparent;
   border-radius: var(--radius-md);
   padding: var(--spacing-3) var(--spacing-4);
@@ -236,12 +236,12 @@
 /* Dark mode specific adjustments for textarea */
 @media (prefers-color-scheme: dark) {
   .textarea {
-    background: var(--neutral-900); /* Closer to background color */
-    border: 1px solid var(--neutral-800); /* Subtle border for visibility */
+    background: var(--neutral-800); /* Lighter gray for more subtle appearance in dark mode */
+    border: 1px solid var(--neutral-700); /* Subtle border for visibility */
   }
   
   .textarea:focus {
-    background: var(--neutral-800); /* Slightly lighter on focus */
+    background: var(--neutral-700); /* Slightly lighter on focus */
     border-color: var(--primary-solid);
   }
 }


### PR DESCRIPTION
## Summary
- ライトモードとダークモードのテキストインプットの色をより控えめに調整
- インプットとして認識できる程度のバランスを保ちながら目立ちすぎない色合いに

## Test plan
- ライトモードでテキストインプットが薄いグレーで表示されることを確認
- ダークモードでテキストインプットが薄いグレーで表示されることを確認
- 両モードでインプットが認識できることを確認

Resolves #74

🤖 Generated with [Claude Code](https://claude.ai/code)