### PR TITLE
Fix: テーマチップスの黒画面問題を修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,12 +77,6 @@
                         GridMeを共有
                     </button>
                 </div>
-
-                
-                <!-- 3x3 テーマグリッド -->
-                <div class="theme-grid" id="theme-grid">
-                    <!-- 9個のグリッドアイテムを動的に生成 -->
-                </div>
                 
                 <!-- テーマサジェスチョンチップス -->
                 <div class="theme-suggestions-container">

--- a/styles/app.css
+++ b/styles/app.css
@@ -720,11 +720,11 @@ body {
     max-width: 800px;
     width: 100%;
     margin: 0 auto;
-    background: #000000;
+    background: var(--bg-secondary);
     padding: var(--spacing-6);
     border-radius: var(--radius-xl);
     box-shadow: var(--shadow-xl);
-    border: 2px solid #000000;
+    border: 2px solid var(--border-primary);
 }
 
 .grid-theme-item {
@@ -858,6 +858,10 @@ body {
     margin-top: var(--spacing-6);
     overflow: hidden;
     position: relative;
+    width: 100%;
+    max-width: 1200px;
+    margin-left: auto;
+    margin-right: auto;
 }
 
 .suggestions-row {
@@ -873,6 +877,7 @@ body {
     animation: slideLeft 30s linear infinite;
     position: absolute;
     white-space: nowrap;
+    padding: var(--spacing-1) 0;
 }
 
 .suggestions-row-2 .suggestions-track {
@@ -972,7 +977,8 @@ body {
     }
     
     .theme-grid {
-        border-color: #ffffff;
+        border-color: var(--border-primary);
+        background: var(--bg-secondary);
     }
     
     .section-title-input {


### PR DESCRIPTION
## Summary
- テーマチップスが黒画面になる問題を修正
- チップスが2行で横にスライドするアニメーションを改善

## Changes
- theme-gridの背景色を適切なCSS変数に変更
- ダークモード対応を追加
- 重複していたtheme-grid要素を削除

Closes #77

Generated with [Claude Code](https://claude.ai/code)