### PR TITLE
fix: ダークモード時のヘッダーとテーマ切り替えボタンの色を修正

### DIFF
--- a/styles/app.css
+++ b/styles/app.css
@@ -559,9 +559,15 @@ body {
     padding: var(--spacing-4) 0;
 }
 
+/* ダークモード時のヘッダー背景を黒に */
+.dark-theme .app-header {
+    background: rgba(0, 0, 0, 0.9);
+    backdrop-filter: blur(10px);
+}
+
 @media (prefers-color-scheme: dark) {
     .app-header {
-        background: var(--bg-primary);
+        background: rgba(0, 0, 0, 0.9);
     }
 }
 
@@ -580,6 +586,17 @@ body {
     display: flex;
     align-items: center;
     gap: var(--spacing-4);
+}
+
+/* ダークモード時のテーマ切り替えボタンの色を白に */
+.dark-theme .theme-toggle {
+    color: white;
+}
+
+@media (prefers-color-scheme: dark) {
+    .theme-toggle {
+        color: white;
+    }
 }
 
 .app-main {

--- a/styles/components.css
+++ b/styles/components.css
@@ -112,6 +112,27 @@
   transform: scale(1.1);
 }
 
+/* ダークモード時のアイコンボタンスタイル */
+.dark-theme .btn-icon {
+  background: var(--neutral-800);
+  color: white;
+}
+
+.dark-theme .btn-icon:hover {
+  background: var(--neutral-700);
+}
+
+@media (prefers-color-scheme: dark) {
+  .btn-icon {
+    background: var(--neutral-800);
+    color: white;
+  }
+  
+  .btn-icon:hover {
+    background: var(--neutral-700);
+  }
+}
+
 /* ===== カード ===== */
 
 /* ベースカード */


### PR DESCRIPTION
## Summary
ダークモード時のヘッダーとテーマ切り替えボタンの色を修正しました。

## Changes
- ヘッダー背景色を黒に変更 (rgba(0, 0, 0, 0.9))
- テーマ切り替えボタンアイコンを白色に変更
- btn-iconクラスにダークモード対応を追加

Closes #78

Generated with [Claude Code](https://claude.ai/code)