### PR TITLE
feat: 共有ページに画像アップロードとカードフリップ機能を追加

### DIFF
--- a/styles/shared.css
+++ b/styles/shared.css
@@ -63,6 +63,7 @@
     font-weight: var(--font-bold);
     color: var(--text-primary);
     margin-bottom: var(--spacing-1);
+    text-align: center;
 }
 
 /* テーマバッジ */
@@ -84,6 +85,90 @@
     font-size: var(--text-sm);
     line-height: var(--leading-relaxed);
     overflow-y: auto;
+}
+
+/* ===== 写真表示エリア ===== */
+.photo-display-area {
+    position: relative;
+    width: 100%;
+    aspect-ratio: 1;
+    background: rgba(0, 0, 0, 0.05);
+    border: 2px dashed rgba(0, 0, 0, 0.2);
+    border-radius: var(--radius-md);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    transition: all var(--transition-base);
+    overflow: hidden;
+    perspective: 1000px;
+}
+
+.photo-display-area:hover {
+    background: rgba(0, 0, 0, 0.08);
+    border-color: rgba(0, 0, 0, 0.3);
+}
+
+/* カードフリップコンテナ */
+.flip-card-inner {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    transition: transform 0.6s;
+    transform-style: preserve-3d;
+}
+
+.photo-display-area.flipped .flip-card-inner {
+    transform: rotateY(180deg);
+}
+
+/* カードの表面と裏面 */
+.flip-card-front,
+.flip-card-back {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    backface-visibility: hidden;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: var(--radius-md);
+}
+
+.flip-card-back {
+    transform: rotateY(180deg);
+    background: var(--bg-primary);
+    padding: var(--spacing-4);
+}
+
+/* プラスアイコン */
+.add-photo-icon {
+    width: 48px;
+    height: 48px;
+    color: var(--text-tertiary);
+    transition: all var(--transition-base);
+}
+
+.photo-display-area:hover .add-photo-icon {
+    color: var(--text-secondary);
+    transform: scale(1.1);
+}
+
+/* アップロードされた画像 */
+.uploaded-image {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    border-radius: var(--radius-md);
+}
+
+/* テーマテキスト（カードの裏面） */
+.theme-text {
+    font-size: var(--text-xl);
+    font-weight: var(--font-bold);
+    color: var(--text-primary);
+    text-align: center;
+    word-break: break-word;
 }
 
 /* テーマ別スタイル（共有ページ） */
@@ -142,8 +227,17 @@
     }
     
     .photo-display-area {
-        background: rgba(0, 0, 0, 0.3);
-        border-color: rgba(255, 255, 255, 0.1);
+        background: rgba(255, 255, 255, 0.05);
+        border-color: rgba(255, 255, 255, 0.2);
+    }
+    
+    .photo-display-area:hover {
+        background: rgba(255, 255, 255, 0.08);
+        border-color: rgba(255, 255, 255, 0.3);
+    }
+    
+    .flip-card-back {
+        background: var(--bg-secondary);
     }
 }
 
@@ -230,5 +324,14 @@
     
     .photo-placeholder span {
         font-size: var(--text-xs);
+    }
+    
+    .add-photo-icon {
+        width: 32px;
+        height: 32px;
+    }
+    
+    .theme-text {
+        font-size: var(--text-base);
     }
 }


### PR DESCRIPTION
## 概要
共有ページに画像アップロード機能とカードフリップアニメーションを実装しました。

## 変更内容
- 各グリッドアイテムに画像アップロード機能を追加（プラスアイコン付き）
- 画像タップ時のカードフリップアニメーションを実装
- フリップ時にテーマテキストが中央に表示される機能を追加
- テーマタイトルを初期状態でグリッドの中央に配置
- ドラッグ＆ドロップでの画像アップロードに対応
- レスポンシブデザインとダークモード対応

## 関連イシュー
Closes #85

Generated with [Claude Code](https://claude.ai/code)