### PR TITLE
fix: ダークモード時のグリッドサイズドロップダウンの背景色を修正

### DIFF
--- a/styles/components.css
+++ b/styles/components.css
@@ -221,9 +221,19 @@
 }
 
 /* Dark mode specific adjustments for inputs */
+.dark-theme .input {
+  background: var(--neutral-800); /* Match header button color */
+  border: 1px solid var(--neutral-700); /* Subtle border for visibility */
+}
+
+.dark-theme .input:focus {
+  background: var(--neutral-700); /* Slightly lighter on focus */
+  border-color: var(--primary-solid);
+}
+
 @media (prefers-color-scheme: dark) {
   .input {
-    background: #2d3748; /* Updated to requested dark mode color */
+    background: var(--neutral-800); /* Match header button color */
     border: 1px solid var(--neutral-700); /* Subtle border for visibility */
   }
   


### PR DESCRIPTION
## Summary
- ダークモード時のグリッドサイズドロップダウンの背景色をヘッダーボタンと同じ色に変更
- `.input` クラスの背景色を `var(--neutral-800)` に更新
- `dark-theme` クラスと `prefers-color-scheme: dark` の両方に対応

## Test plan
- [ ] ダークモードに切り替えて、グリッドサイズドロップダウンがヘッダーボタンと同じ色になっていることを確認
- [ ] ライトモードでも正常に動作することを確認
- [ ] ドロップダウンのフォーカス時のスタイルが正しく適用されることを確認

Resolves #88

🤖 Generated with [Claude Code](https://claude.ai/code)