### PR TITLE
fix: set 3x3 as default grid, add random themes, and lighten input background

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,8 +56,8 @@
                 <div class="grid-size-selector">
                     <label for="grid-size">グリッドサイズ:</label>
                     <select id="grid-size" class="input">
-                        <option value="2" selected>2x2</option>
-                        <option value="3">3x3</option>
+                        <option value="2">2x2</option>
+                        <option value="3" selected>3x3</option>
                     </select>
                 </div>
                 

--- a/js/photo-grid.js
+++ b/js/photo-grid.js
@@ -9,7 +9,7 @@
     
     // 状態管理
     const state = {
-        gridSize: 2, // デフォルトを2x2に設定
+        gridSize: 3, // デフォルトを3x3に設定
         gridSections: [], // グリッドセクションを格納
         saveTimeout: null,
         currentFocusedInput: null // 現在フォーカスされている入力フィールド
@@ -23,6 +23,11 @@
         '国', '都市', '自然現象', '職業', '感情',
         '時代', '神話', '星座', '元素', 'ポケモン'
     ];
+    
+    // ランダムテーマを取得する関数
+    function getRandomTheme() {
+        return themeSuggestions[Math.floor(Math.random() * themeSuggestions.length)];
+    }
     
     // DOM要素
     const elements = {
@@ -61,7 +66,10 @@
         for (let i = 0; i < totalSections; i++) {
             const row = Math.floor(i / size);
             const col = i % size;
-            state.gridSections.push(new GridSection(i, row, col));
+            const section = new GridSection(i, row, col);
+            // ランダムテーマを初期値として設定
+            section.title = getRandomTheme();
+            state.gridSections.push(section);
         }
         
         // グリッドHTMLの生成
@@ -181,7 +189,7 @@
         const newSize = parseInt(e.target.value);
         
         // 確認ダイアログ
-        if (state.gridSections.some(section => section.title || section.content)) {
+        if (state.gridSections.some(section => section.title)) {
             if (!confirm('グリッドサイズを変更すると、現在の内容が失われます。続行しますか？')) {
                 e.target.value = state.gridSize;
                 return;
@@ -301,7 +309,7 @@
         if (savedData) {
             try {
                 const data = JSON.parse(savedData);
-                state.gridSize = data.size || 2;
+                state.gridSize = data.size || 3;
                 
                 // グリッドサイズセレクトを更新
                 if (elements.gridSizeSelect) {

--- a/styles/app.css
+++ b/styles/app.css
@@ -779,14 +779,14 @@ body {
     font-size: var(--text-sm);
     font-weight: var(--font-normal);
     transition: all var(--transition-base);
-    background: rgba(0, 0, 0, 0.08); /* More gray/visible in light mode */
+    background: rgba(0, 0, 0, 0.03); /* Lighter gray background */
     color: var(--text-secondary);
 }
 
 .section-title-input:focus {
     outline: none;
     box-shadow: none;
-    background: rgba(0, 0, 0, 0.12); /* Darker on focus */
+    background: rgba(0, 0, 0, 0.05); /* Slightly darker on focus */
 }
 
 /* セクションテーマ選択 */
@@ -999,12 +999,12 @@ body {
     }
     
     .section-title-input {
-        background: rgba(255, 255, 255, 0.03); /* Much closer to background, less prominent */
+        background: rgba(255, 255, 255, 0.02); /* Even lighter in dark mode */
         color: var(--text-secondary);
     }
     
     .section-title-input:focus {
-        background: rgba(255, 255, 255, 0.05); /* Subtle increase on focus */
+        background: rgba(255, 255, 255, 0.04); /* Very subtle increase on focus */
     }
     
 }


### PR DESCRIPTION
## Summary
- Changed default grid size from 2x2 to 3x3
- Added random theme generation for input fields
- Made input background color much lighter gray

## Test plan
- [ ] Verify grid defaults to 3x3 on page load
- [ ] Verify random themes appear in input fields
- [ ] Verify themes can be changed by user
- [ ] Verify input background is lighter gray
- [ ] Test in both light and dark modes

Closes #87

🤖 Generated with [Claude Code](https://claude.ai/code)