### PR TITLE
テーマチップスのスタイルとレイアウトを更新

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,11 +61,6 @@
                     </select>
                 </div>
                 
-                <!-- 3x3 テーマグリッド -->
-                <div class="theme-grid" id="theme-grid">
-                    <!-- 9個のグリッドアイテムを動的に生成 -->
-                </div>
-                
                 <!-- 共有ボタン -->
                 <div class="share-button-container">
                     <button class="btn-primary btn-lg" id="main-share-btn">
@@ -90,6 +85,11 @@
                             <!-- チップは動的に生成される -->
                         </div>
                     </div>
+                </div>
+                
+                <!-- 3x3 テーマグリッド -->
+                <div class="theme-grid" id="theme-grid">
+                    <!-- 9個のグリッドアイテムを動的に生成 -->
                 </div>
 
             </section>

--- a/styles/app.css
+++ b/styles/app.css
@@ -872,7 +872,8 @@ body {
 
 /* テーマサジェスチョンチップス */
 .theme-suggestions-container {
-    margin-top: var(--spacing-6);
+    margin-top: var(--spacing-4);
+    margin-bottom: var(--spacing-6);
     overflow: hidden;
     position: relative;
     width: 100%;
@@ -883,8 +884,8 @@ body {
 
 .suggestions-row {
     position: relative;
-    height: 60px;
-    margin-bottom: var(--spacing-3);
+    height: 44px;
+    margin-bottom: var(--spacing-2);
     overflow: hidden;
 }
 
@@ -923,41 +924,40 @@ body {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    padding: var(--spacing-3) var(--spacing-5);
-    border-radius: 30px;
-    font-size: var(--text-lg);
+    padding: var(--spacing-2) var(--spacing-4);
+    border-radius: 20px;
+    font-size: var(--text-sm);
     font-weight: var(--font-medium);
     color: white;
     cursor: pointer;
     transition: all var(--transition-base);
     user-select: none;
-    min-width: 120px;
-    height: 50px;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
-    /* フォールバック背景色を追加 */
-    background: var(--gradient-primary);
+    min-width: 80px;
+    height: 36px;
+    /* 影を削除 */
+    background: var(--primary-solid);
 }
 
 .theme-chip:hover {
     transform: scale(1.05);
-    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.15);
+    opacity: 0.9;
 }
 
 .theme-chip:active {
     transform: scale(0.98);
 }
 
-/* チップのカラフルな背景色 */
-.chip-color-1 { background: linear-gradient(135deg, #667eea 0%, #764ba2 100%) !important; }
-.chip-color-2 { background: linear-gradient(135deg, #f093fb 0%, #f5576c 100%) !important; }
-.chip-color-3 { background: linear-gradient(135deg, #4facfe 0%, #00f2fe 100%) !important; }
-.chip-color-4 { background: linear-gradient(135deg, #43e97b 0%, #38f9d7 100%) !important; }
-.chip-color-5 { background: linear-gradient(135deg, #fa709a 0%, #fee140 100%) !important; }
-.chip-color-6 { background: linear-gradient(135deg, #30cfd0 0%, #330867 100%) !important; }
-.chip-color-7 { background: linear-gradient(135deg, #a8edea 0%, #fed6e3 100%) !important; }
-.chip-color-8 { background: linear-gradient(135deg, #ffd89b 0%, #19547b 100%) !important; }
-.chip-color-9 { background: linear-gradient(135deg, #ff9a9e 0%, #fecfef 100%) !important; }
-.chip-color-10 { background: linear-gradient(135deg, #fbc2eb 0%, #a6c1ee 100%) !important; }
+/* チップのカラフルな背景色（単色） */
+.chip-color-1 { background: #667eea !important; }
+.chip-color-2 { background: #f093fb !important; }
+.chip-color-3 { background: #4facfe !important; }
+.chip-color-4 { background: #43e97b !important; }
+.chip-color-5 { background: #fa709a !important; }
+.chip-color-6 { background: #30cfd0 !important; }
+.chip-color-7 { background: #FF6B35 !important; }
+.chip-color-8 { background: #06B6D4 !important; }
+.chip-color-9 { background: #EC4899 !important; }
+.chip-color-10 { background: #10B981 !important; }
 
 /* ダークモード対応 */
 @media (prefers-color-scheme: dark) {


### PR DESCRIPTION
## 概要

issue #89 での要望に従い、テーマサジェスチョンチップスのスタイルとレイアウトを更新しました。

## 変更内容

- チップの背景をグラデーションから単色に変更
- チップのサイズを小さく調整（height: 36px、font-size: var(--text-sm)）
- チップを共有ボタンとグリッドの間に配置
- 適切なマージンを追加（上: --spacing-4、下: --spacing-6）
- チップから影を削除

Closes #89

Generated with [Claude Code](https://claude.ai/code)