### PR TITLE
fix: correct grid background color and border styling

### DIFF
--- a/styles/shared.css
+++ b/styles/shared.css
@@ -25,11 +25,11 @@
     gap: var(--spacing-4);
     max-width: 900px;
     margin: 0 auto var(--spacing-10);
-    background: #000000;
+    background: var(--bg-secondary);
     padding: var(--spacing-6);
     border-radius: var(--radius-xl);
     box-shadow: var(--shadow-xl);
-    border: 2px solid #000000;
+    border: 2px solid var(--border-primary);
 }
 
 .photo-theme-item {
@@ -223,7 +223,7 @@
     }
     
     .photo-theme-grid {
-        border-color: #ffffff;
+        border-color: var(--border-primary);
     }
     
     .photo-display-area {


### PR DESCRIPTION
## Summary

This PR fixes the black grid display issue on the shared page.

## Changes
- Updated photo-theme-grid background from hardcoded #000000 to var(--bg-secondary)
- Changed border color to use var(--border-primary) for proper theme support
- Ensures grid displays correctly in both light and dark modes

Fixes #92

Generated with [Claude Code](https://claude.ai/code)