### PR TITLE
fix: prevent viewport zoom on input focus for mobile devices

### DIFF
--- a/examples/demo.html
+++ b/examples/demo.html
@@ -2,7 +2,7 @@
 <html lang="ja">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <title>GridMe デザインシステム デモ</title>
     
     <!-- フォントの読み込み -->

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="ja">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <title>GridMe - フォトグリッドアプリケーション</title>
     <meta name="description" content="テーマに基づいて写真を配置できるインタラクティブなフォトグリッドアプリ">
     

--- a/shared.html
+++ b/shared.html
@@ -2,7 +2,7 @@
 <html lang="ja">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <title>GridMe - 共有されたテーマグリッド</title>
     <meta name="description" content="共有されたテーマグリッドに写真を追加">
     

--- a/styles/app.css
+++ b/styles/app.css
@@ -1161,6 +1161,27 @@ body {
     }
 }
 
+/* ===== モバイルでのインプットズーム防止 ===== */
+@media (max-width: 768px) {
+    /* 全ての入力フィールドで最小16pxのフォントサイズを確保 */
+    input[type="text"],
+    input[type="email"],
+    input[type="number"],
+    input[type="tel"],
+    input[type="url"],
+    input[type="search"],
+    input[type="password"],
+    textarea,
+    select {
+        font-size: 16px !important;
+    }
+    
+    /* 特定のクラスに対する上書き */
+    .section-title-input {
+        font-size: 16px !important;
+    }
+}
+
 /* ===== レスポンシブ ===== */
 @media (max-width: 768px) {
     .nav-menu {


### PR DESCRIPTION
## Summary

- Fixed viewport zoom issue on mobile devices when focusing input fields
- Updated viewport meta tags to prevent zooming
- Added CSS rule for minimum 16px font-size on mobile inputs

Closes #94

🤖 Generated with [Claude Code](https://claude.ai/code)