### PR TITLE
fix: reorder grid components and add team sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,16 +61,66 @@
                     </select>
                 </div>
                 
-                <!-- 共有ボタン -->
-                <div class="share-button-container">
-                    <button class="btn-primary btn-lg" id="main-share-btn">
-                        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="margin-right: 8px;">
-                            <path d="M4 12v8a2 2 0 002 2h12a2 2 0 002-2v-8"/>
-                            <polyline points="16 6 12 2 8 6"/>
-                            <line x1="12" y1="2" x2="12" y2="15"/>
-                        </svg>
-                        GridMeを共有
-                    </button>
+                <!-- 3x3 テーマグリッド -->
+                <div class="theme-grid" id="theme-grid">
+                    <!-- 9個のグリッドアイテムを動的に生成 -->
+                </div>
+                
+                <!-- チームセクション（3つ） -->
+                <div class="team-sections">
+                    <div class="team-section">
+                        <h3 class="team-title">チーム 1</h3>
+                        <div class="team-members">
+                            <div class="team-member">
+                                <div class="member-avatar"></div>
+                                <span class="member-name">メンバー 1</span>
+                            </div>
+                            <div class="team-member">
+                                <div class="member-avatar"></div>
+                                <span class="member-name">メンバー 2</span>
+                            </div>
+                            <div class="team-member">
+                                <div class="member-avatar"></div>
+                                <span class="member-name">メンバー 3</span>
+                            </div>
+                        </div>
+                    </div>
+                    
+                    <div class="team-section">
+                        <h3 class="team-title">チーム 2</h3>
+                        <div class="team-members">
+                            <div class="team-member">
+                                <div class="member-avatar"></div>
+                                <span class="member-name">メンバー 1</span>
+                            </div>
+                            <div class="team-member">
+                                <div class="member-avatar"></div>
+                                <span class="member-name">メンバー 2</span>
+                            </div>
+                            <div class="team-member">
+                                <div class="member-avatar"></div>
+                                <span class="member-name">メンバー 3</span>
+                            </div>
+                        </div>
+                    </div>
+                    
+                    <div class="team-section">
+                        <h3 class="team-title">チーム 3</h3>
+                        <div class="team-members">
+                            <div class="team-member">
+                                <div class="member-avatar"></div>
+                                <span class="member-name">メンバー 1</span>
+                            </div>
+                            <div class="team-member">
+                                <div class="member-avatar"></div>
+                                <span class="member-name">メンバー 2</span>
+                            </div>
+                            <div class="team-member">
+                                <div class="member-avatar"></div>
+                                <span class="member-name">メンバー 3</span>
+                            </div>
+                        </div>
+                    </div>
                 </div>
                 
                 <!-- テーマサジェスチョンチップス -->
@@ -87,9 +137,16 @@
                     </div>
                 </div>
                 
-                <!-- 3x3 テーマグリッド -->
-                <div class="theme-grid" id="theme-grid">
-                    <!-- 9個のグリッドアイテムを動的に生成 -->
+                <!-- 共有ボタン -->
+                <div class="share-button-container">
+                    <button class="btn-primary btn-lg" id="main-share-btn">
+                        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="margin-right: 8px;">
+                            <path d="M4 12v8a2 2 0 002 2h12a2 2 0 002-2v-8"/>
+                            <polyline points="16 6 12 2 8 6"/>
+                            <line x1="12" y1="2" x2="12" y2="15"/>
+                        </svg>
+                        GridMeを共有
+                    </button>
                 </div>
 
             </section>

--- a/styles/app.css
+++ b/styles/app.css
@@ -1342,3 +1342,87 @@ body {
 .dark-theme .share-url-preview {
     border-color: var(--neutral-700);
 }
+
+/* ===== チームセクション ===== */
+.team-sections {
+    width: 100%;
+    max-width: 1200px;
+    margin: var(--spacing-8) auto;
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: var(--spacing-6);
+}
+
+.team-section {
+    background: var(--bg-secondary);
+    border-radius: var(--radius-lg);
+    padding: var(--spacing-6);
+    box-shadow: var(--shadow-md);
+    border: 1px solid var(--border-primary);
+    transition: all var(--transition-base);
+}
+
+.team-section:hover {
+    transform: translateY(-2px);
+    box-shadow: var(--shadow-lg);
+}
+
+.team-title {
+    font-size: var(--text-xl);
+    font-weight: var(--font-bold);
+    margin-bottom: var(--spacing-4);
+    text-align: center;
+    color: var(--text-primary);
+}
+
+.team-members {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-3);
+}
+
+.team-member {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-3);
+    padding: var(--spacing-2);
+    background: var(--bg-primary);
+    border-radius: var(--radius-md);
+    transition: all var(--transition-base);
+}
+
+.team-member:hover {
+    background: var(--bg-tertiary);
+}
+
+.member-avatar {
+    width: 40px;
+    height: 40px;
+    border-radius: var(--radius-full);
+    background: var(--gradient-primary);
+    flex-shrink: 0;
+}
+
+.member-name {
+    font-size: var(--text-sm);
+    font-weight: var(--font-medium);
+    color: var(--text-secondary);
+}
+
+/* チームセクションのレスポンシブ */
+@media (max-width: 968px) {
+    .team-sections {
+        grid-template-columns: 1fr;
+        gap: var(--spacing-4);
+    }
+}
+
+@media (max-width: 768px) {
+    .team-section {
+        padding: var(--spacing-4);
+    }
+    
+    .team-title {
+        font-size: var(--text-lg);
+    }
+}


### PR DESCRIPTION
## Summary

Fixed the grid positioning by reordering components and adding team sections.

## Changes
- Moved theme grid after grid size selector
- Added 3 team sections with member displays
- Moved theme suggestion chips after team sections
- Moved share button to the bottom
- Added responsive CSS styling

Fixes #97

🤖 Generated with [Claude Code](https://claude.ai/code)