### PR TITLE
fix: Instagram Stories共有機能のバグを修正

### DIFF
--- a/js/photo-grid.js
+++ b/js/photo-grid.js
@@ -44,8 +44,7 @@
         shareFacebookBtn: document.getElementById('share-facebook-btn'),
         shareLineBtn: document.getElementById('share-line-btn'),
         shareInstagramBtn: document.getElementById('share-instagram-btn'),
-        shareUrlInput: document.getElementById('share-url-input'),
-        photoThemeGrid: document.getElementById('photo-theme-grid')
+        shareUrlInput: document.getElementById('share-url-input')
     };
     
     // グリッドセクションクラス
@@ -309,7 +308,7 @@
     
     // Instagram Stories用の画像を作成
     function createInstagramStoriesImage() {
-        const gridContainer = elements.photoThemeGrid;
+        const gridContainer = elements.themeGrid;
         
         // Create a temporary container for Instagram Stories format (9:16 aspect ratio)
         const tempContainer = document.createElement('div');


### PR DESCRIPTION
## 概要

Instagram共有ボタンが動作しない問題を修正しました。

## 変更内容
- 存在しないDOM要素IDへの参照を修正 (photo-theme-grid → theme-grid)
- 未使用のphotoThemeGrid要素の定義を削除

## 修正後の動作
Instagram Storiesボタンをクリックすると、グリッドが9:16の画像としてダウンロードされ、Instagramのストーリーズに投稿できるようになります。

Fixes #106

Generated with [Claude Code](https://claude.ai/code)