### PR TITLE
fix: テーマチップスを画面幅いっぱいに拡張

### DIFF
--- a/styles/app.css
+++ b/styles/app.css
@@ -881,10 +881,9 @@ body {
     margin-bottom: var(--spacing-6);
     overflow: hidden;
     position: relative;
-    width: 100%;
-    max-width: 1200px;
-    margin-left: auto;
-    margin-right: auto;
+    width: 100vw;
+    margin-left: calc(-50vw + 50%);
+    margin-right: calc(-50vw + 50%);
 }
 
 .suggestions-row {


### PR DESCRIPTION
## Summary
- テーマチップスの横の余白を削除し、画面幅いっぱいに拡張
- 画面からはみ出るような演出を実装

Closes #118

Generated with [Claude Code](https://claude.ai/code)