### PR TITLE
fix: reduce top margin above grid size selector

### DIFF
--- a/styles/app.css
+++ b/styles/app.css
@@ -702,7 +702,7 @@ body {
     align-items: center;
     justify-content: center;
     min-height: calc(100vh - 200px);
-    padding: var(--spacing-8) 0;
+    padding: var(--spacing-4) 0;
 }
 
 /* ===== グリッドサイズセレクター ===== */


### PR DESCRIPTION
## Summary

This PR reduces the excessive top margin above the grid size selector by adjusting the padding of the grid main section.

## Changes
- Reduced the top padding of `.grid-main-section` from `var(--spacing-8)` (2rem) to `var(--spacing-4)` (1rem)
- This makes the spacing above the grid size selector more compact

Closes #119

Generated with [Claude Code](https://claude.ai/code)