### PR TITLE
feat: change accent color from gradients to solid #FF8B25

### DIFF
--- a/styles/app.css
+++ b/styles/app.css
@@ -852,7 +852,7 @@ body {
 .section-theme-select:focus {
     outline: none;
     border-color: var(--primary-solid);
-    box-shadow: 0 0 0 3px rgba(255, 107, 53, 0.1);
+    box-shadow: 0 0 0 3px rgba(255, 139, 37, 0.1);
 }
 
 /* セクションコンテンツ入力 */
@@ -873,7 +873,7 @@ body {
 .section-content-input:focus {
     outline: none;
     border-color: var(--primary-solid);
-    box-shadow: 0 0 0 3px rgba(255, 107, 53, 0.1);
+    box-shadow: 0 0 0 3px rgba(255, 139, 37, 0.1);
 }
 
 /* Dark mode styles for section inputs */
@@ -1000,7 +1000,7 @@ body {
 .chip-color-4 { background: #43e97b !important; }
 .chip-color-5 { background: #fa709a !important; }
 .chip-color-6 { background: #30cfd0 !important; }
-.chip-color-7 { background: #FF6B35 !important; }
+.chip-color-7 { background: #FF8B25 !important; }
 .chip-color-8 { background: #06B6D4 !important; }
 .chip-color-9 { background: #EC4899 !important; }
 .chip-color-10 { background: #10B981 !important; }

--- a/styles/components.css
+++ b/styles/components.css
@@ -28,7 +28,7 @@
 
 .btn-primary:hover {
   transform: translateY(-2px);
-  box-shadow: 0 10px 20px rgba(255, 107, 53, 0.3);
+  box-shadow: 0 10px 20px rgba(255, 139, 37, 0.3);
 }
 
 .btn-primary:active {
@@ -213,7 +213,7 @@
 .input:focus {
   border-color: var(--primary-solid);
   background: var(--bg-primary);
-  box-shadow: 0 0 0 4px rgba(255, 107, 53, 0.1);
+  box-shadow: 0 0 0 4px rgba(255, 139, 37, 0.1);
 }
 
 .input::placeholder {
@@ -261,7 +261,7 @@
 .textarea:focus {
   border-color: var(--primary-solid);
   background: var(--bg-primary);
-  box-shadow: 0 0 0 4px rgba(255, 107, 53, 0.1);
+  box-shadow: 0 0 0 4px rgba(255, 139, 37, 0.1);
 }
 
 /* Dark mode specific adjustments for textarea */
@@ -524,9 +524,9 @@
 
 .glow {
   box-shadow: 
-    0 0 20px rgba(255, 107, 53, 0.5),
-    0 0 40px rgba(255, 107, 53, 0.3),
-    0 0 60px rgba(255, 107, 53, 0.1);
+    0 0 20px rgba(255, 139, 37, 0.5),
+    0 0 40px rgba(255, 139, 37, 0.3),
+    0 0 60px rgba(255, 139, 37, 0.1);
 }
 
 .gradient-text {

--- a/styles/design-tokens.css
+++ b/styles/design-tokens.css
@@ -10,11 +10,11 @@
   /* ===== カラーパレット ===== */
   
   /* プライマリカラー */
-  --primary-gradient-start: #FF6B35;
-  --primary-gradient-end: #F7931E;
-  --primary-solid: #FF6B35;
-  --primary-light: #FFB088;
-  --primary-dark: #E55100;
+  --primary-gradient-start: #FF8B25;
+  --primary-gradient-end: #FF8B25;
+  --primary-solid: #FF8B25;
+  --primary-light: #FFAB6B;
+  --primary-dark: #E06F00;
   
   /* セカンダリカラー */
   --secondary-cyan: #06B6D4;
@@ -35,7 +35,7 @@
   --neutral-950: #09090B;
   
   /* アクセントカラー */
-  --accent-neon-orange: #FF4500;
+  --accent-neon-orange: #FF8B25;
   --accent-neon-green: #39FF14;
   --accent-coral: #FF6B6B;
   --accent-yellow: #FFD93D;
@@ -181,13 +181,13 @@
 
 /* ===== グラデーション定義 ===== */
 :root {
-  --gradient-primary: linear-gradient(135deg, var(--primary-gradient-start), var(--primary-gradient-end));
+  --gradient-primary: var(--primary-solid);
   --gradient-mesh: 
     radial-gradient(circle at 20% 50%, var(--accent-neon-orange) 0%, transparent 50%),
     radial-gradient(circle at 80% 80%, var(--secondary-cyan) 0%, transparent 50%),
     radial-gradient(circle at 40% 20%, var(--secondary-pink) 0%, transparent 50%);
-  --gradient-sunset: linear-gradient(135deg, #FF6B35 0%, #F7931E 25%, #f093fb 50%, #f5576c 75%, #fda085 100%);
-  --gradient-ocean: linear-gradient(135deg, #06B6D4 0%, #3B82F6 50%, #FF6B35 100%);
+  --gradient-sunset: linear-gradient(135deg, #FF8B25 0%, #FF8B25 25%, #f093fb 50%, #f5576c 75%, #fda085 100%);
+  --gradient-ocean: linear-gradient(135deg, #06B6D4 0%, #3B82F6 50%, #FF8B25 100%);
 }
 
 /* ===== アニメーション定義 ===== */


### PR DESCRIPTION
## Summary
- Changed accent color from gradients to solid color #FF8B25 as requested
- Updated the design system tokens and all related CSS files

## Changes
- Updated primary colors in design-tokens.css to use #FF8B25
- Changed gradient-primary to use solid color instead of gradient
- Updated all box-shadow rgba values to match new color
- Fixed chip color and glow effects
- Adjusted light/dark variations to complement new color

Closes #129

Generated with [Claude Code](https://claude.ai/code)