### PR TITLE
feat: center logo and remove header buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,25 +24,6 @@
                 <h1 class="app-title">
                     <img src="assets/logos/GridMe_logo.png" alt="GridMe" style="height: 40px; vertical-align: middle;">
                 </h1>
-                
-                <div class="header-actions">
-                    <button class="btn-icon theme-toggle" aria-label="テーマ切り替え">
-                        <svg class="icon-sun" width="20" height="20" viewBox="0 0 20 20" fill="currentColor">
-                            <path d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z"/>
-                        </svg>
-                        <svg class="icon-moon" width="20" height="20" viewBox="0 0 20 20" fill="currentColor" style="display: none;">
-                            <path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"/>
-                        </svg>
-                    </button>
-                    <button class="btn-primary btn-sm" id="share-btn">
-                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="margin-right: 6px;">
-                            <path d="M4 12v8a2 2 0 002 2h12a2 2 0 002-2v-8"/>
-                            <polyline points="16 6 12 2 8 6"/>
-                            <line x1="12" y1="2" x2="12" y2="15"/>
-                        </svg>
-                        共有
-                    </button>
-                </div>
             </div>
         </div>
     </header>

--- a/shared.html
+++ b/shared.html
@@ -27,20 +27,6 @@
                         <img src="assets/logos/GridMe_logo.png" alt="GridMe" style="height: 40px; vertical-align: middle;">
                     </a>
                 </h1>
-                
-                <div class="header-actions">
-                    <button class="btn-icon theme-toggle" aria-label="テーマ切り替え">
-                        <svg class="icon-sun" width="20" height="20" viewBox="0 0 20 20" fill="currentColor">
-                            <path d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z"/>
-                        </svg>
-                        <svg class="icon-moon" width="20" height="20" viewBox="0 0 20 20" fill="currentColor" style="display: none;">
-                            <path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"/>
-                        </svg>
-                    </button>
-                    <a href="./index.html" class="btn-primary btn-sm">
-                        新しいGridMeを作成
-                    </a>
-                </div>
             </div>
         </div>
     </header>

--- a/styles/app.css
+++ b/styles/app.css
@@ -574,7 +574,7 @@ body {
 .header-content {
     display: flex;
     align-items: center;
-    justify-content: space-between;
+    justify-content: center;
 }
 
 .app-title {


### PR DESCRIPTION
## Summary
- Center aligned the GridMe logo in header
- Removed theme toggle button (switch screen mode) and share button as requested
- Updated CSS to center the logo

## Test plan
- [ ] Verify logo is centered on index.html
- [ ] Verify logo is centered on shared.html
- [ ] Confirm theme toggle button is removed
- [ ] Confirm share button is removed from header
- [ ] Check that dark mode still works via system preferences

Closes #139

🤖 Generated with [Claude Code](https://claude.ai/code)