### PR TITLE
fix: ensure Theme text is always center-aligned

### DIFF
--- a/styles/app.css
+++ b/styles/app.css
@@ -807,6 +807,7 @@ body {
 /* グリッドセクションコンテナ */
 .grid-section-container {
     width: 100%;
+    height: 100%;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -817,7 +818,7 @@ body {
     width: 100%;
     border: none;
     border-radius: var(--radius-md);
-    padding: var(--spacing-1) var(--spacing-2);
+    padding: var(--spacing-2) var(--spacing-2);
     font-size: var(--text-sm);
     font-weight: var(--font-normal);
     font-family: inherit;
@@ -828,6 +829,10 @@ body {
     overflow: hidden;
     line-height: 1.4;
     min-height: 2.4em;
+    text-align: center;
+    vertical-align: middle;
+    display: block;
+    margin: auto;
 }
 
 .section-title-input:focus {


### PR DESCRIPTION
## Summary

- Fixed Theme text alignment to ensure it's always centered for both single and multi-line text
- Updated CSS styling for proper vertical and horizontal centering

## Changes

- Added `height: 100%` to `.grid-section-container`
- Updated padding and alignment properties in `.section-title-input`

Closes #140

🤖 Generated with [Claude Code](https://claude.ai/code)