### PR TITLE
fix: align grid number widget and background color picker

### DIFF
--- a/styles/app.css
+++ b/styles/app.css
@@ -726,10 +726,13 @@ body {
 .grid-size-selector label {
     font-weight: var(--font-medium);
     color: var(--text-secondary);
+    line-height: 40px;
 }
 
 .grid-size-selector select {
     min-width: 120px;
+    height: 40px;
+    padding: 0 var(--spacing-3);
 }
 
 /* ===== グリッド背景色セレクター ===== */
@@ -743,6 +746,7 @@ body {
 .grid-bg-color-selector label {
     font-weight: var(--font-medium);
     color: var(--text-secondary);
+    line-height: 40px;
 }
 
 .color-input {


### PR DESCRIPTION
Fixes #141

## Summary
Aligned the grid number widget and background color picker in the top menu by:
- Setting consistent height (40px) for both elements
- Adjusting padding for the select element
- Setting line-height for labels to ensure vertical alignment

Generated with [Claude Code](https://claude.ai/code)