### PR TITLE
fix: reduce grid number dropdown size to minimize padding

### DIFF
--- a/styles/app.css
+++ b/styles/app.css
@@ -718,20 +718,26 @@ body {
 .grid-size-selector {
     display: flex;
     align-items: center;
-    gap: var(--spacing-3);
-    font-size: var(--text-lg);
+    gap: var(--spacing-2);
+    font-size: var(--text-base);
 }
 
 .grid-size-selector label {
     font-weight: var(--font-medium);
     color: var(--text-secondary);
-    line-height: 40px;
+    line-height: 28px;
 }
 
 .grid-size-selector select {
-    min-width: 120px;
-    height: 40px;
-    padding: 0 var(--spacing-3);
+    min-width: 80px;
+    height: 28px;
+    padding: 2px 6px;
+    font-size: var(--text-sm);
+}
+
+/* Override input class padding for grid size selector */
+.grid-size-selector select.input {
+    padding: 2px 6px;
 }
 
 /* ===== グリッド背景色セレクター ===== */


### PR DESCRIPTION
## Summary

Reduced the size of the grid number dropdown to minimize the margin between text inside and outside, as requested in #148.

## Changes
- Reduced dropdown height from 40px to 28px
- Minimized padding to 2px vertical and 6px horizontal
- Reduced minimum width from 120px to 80px
- Adjusted font size and spacing for more compact appearance
- Updated label line-height to match new dropdown height

Closes #148

Generated with [Claude Code](https://claude.ai/code)