### PR TITLE
fix: adjust header bottom margin to 28px and text-to-grid spacing to 8px

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
                 </div>
                 
                 <!-- テーマ説明テキスト -->
-                <div style="text-align: center; margin-bottom: 20px;">
+                <div style="text-align: center; margin-bottom: 8px;">
                     <p style="font-size: 12px; color: gray; margin: 0;">グリッドのテーマは自由に変更できるよ！</p>
                 </div>
                 

--- a/styles/app.css
+++ b/styles/app.css
@@ -556,6 +556,7 @@ body {
     background: rgba(255, 255, 255, 0.9);
     backdrop-filter: blur(10px);
     padding: var(--spacing-4) 0;
+    margin-bottom: 28px;
 }
 
 /* ダークモード時のヘッダー背景を黒に */


### PR DESCRIPTION
## Summary

- Add margin-bottom: 28px to .app-header class
- Reduce spacing between theme text and grid from 20px to 8px

Closes #152

🤖 Generated with [Claude Code](https://claude.ai/code)