### PR TITLE
fix: center theme text both vertically and horizontally

### DIFF
--- a/styles/shared.css
+++ b/styles/shared.css
@@ -88,7 +88,9 @@
 
 /* テーマバッジ */
 .theme-badge {
-    display: inline-block;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
     background: var(--primary-light);
     color: var(--primary-dark);
     padding: var(--spacing-1) var(--spacing-3);
@@ -184,6 +186,10 @@
 
 /* テーマテキスト（カードの裏面） */
 .theme-text {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
     font-size: var(--text-xl);
     font-weight: var(--font-bold);
     color: var(--text-primary);
@@ -265,6 +271,9 @@
     top: 0;
     left: 0;
     right: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     background: rgba(0, 0, 0, 0.7);
     color: white;
     padding: var(--spacing-2) var(--spacing-3);


### PR DESCRIPTION
Fixes #151

## Summary
- Updated CSS for all theme-related text elements to center them both vertically and horizontally
- Applied flexbox centering to .theme-badge, .theme-label, and .theme-text classes

Generated with [Claude Code](https://claude.ai/code)