### PR TITLE
fix: reduce header spacing to 18px and limit grid size to 2x2

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,8 +39,7 @@
                     <div class="grid-size-selector">
                         <label for="grid-size">グリッド数:</label>
                         <select id="grid-size" class="input">
-                            <option value="2">2x2</option>
-                            <option value="3" selected>3x3</option>
+                            <option value="2" selected>2x2</option>
                         </select>
                     </div>
                     
@@ -56,9 +55,9 @@
                     <p style="font-size: 12px; color: gray; margin: 0;">グリッドのテーマは自由に変更できるよ！</p>
                 </div>
                 
-                <!-- 3x3 テーマグリッド -->
+                <!-- テーマグリッド -->
                 <div class="theme-grid" id="theme-grid">
-                    <!-- 9個のグリッドアイテムを動的に生成 -->
+                    <!-- グリッドアイテムを動的に生成 -->
                 </div>
                 
                 

--- a/js/photo-grid.js
+++ b/js/photo-grid.js
@@ -9,7 +9,7 @@
     
     // 状態管理
     const state = {
-        gridSize: 3, // デフォルトを3x3に設定
+        gridSize: 2, // デフォルトを2x2に設定
         gridSections: [], // グリッドセクションを格納
         saveTimeout: null,
         currentFocusedInput: null, // 現在フォーカスされている入力フィールド

--- a/styles/app.css
+++ b/styles/app.css
@@ -556,7 +556,7 @@ body {
     background: rgba(255, 255, 255, 0.9);
     backdrop-filter: blur(10px);
     padding: var(--spacing-4) 0;
-    margin-bottom: 28px;
+    margin-bottom: 18px;
 }
 
 /* ダークモード時のヘッダー背景を黒に */
@@ -702,7 +702,7 @@ body {
     align-items: center;
     justify-content: center;
     min-height: calc(100vh - 200px);
-    padding: var(--spacing-4) 0;
+    padding: 0 0 var(--spacing-4) 0;
 }
 
 /* ===== グリッドコントロール ===== */


### PR DESCRIPTION
Closes #159

## Summary
- Reduced spacing between header and background color selection to 18px
- Limited grid size options to 2x2 only

## Changes
- Updated header bottom margin from 28px to 18px
- Removed top padding from grid-main-section
- Removed 3x3 option from grid size dropdown
- Updated default grid size in JavaScript

Generated with [Claude Code](https://claude.ai/code)