### PR TITLE
fix: center Cancel and Confirm buttons in grid resize warning modal

### DIFF
--- a/styles/app.css
+++ b/styles/app.css
@@ -1158,6 +1158,13 @@ body {
     padding: var(--spacing-6);
 }
 
+.app-modal-footer {
+    display: flex;
+    justify-content: center;
+    gap: var(--spacing-4);
+    padding: 0 var(--spacing-6) var(--spacing-6) var(--spacing-6);
+}
+
 .upload-area {
     border: 2px dashed var(--border-secondary);
     border-radius: var(--radius-lg);


### PR DESCRIPTION
Fixes #161

## Summary

- Added `.app-modal-footer` styling to center the Cancel and Confirm buttons
- Set appropriate spacing between buttons using CSS gap property
- Added bottom padding to increase margin at the bottom of the modal

The buttons are now properly centered with good visual spacing as requested.

Generated with [Claude Code](https://claude.ai/code)