### PR TITLE
fix: improve dark mode visibility for theme chips and grid items

### DIFF
--- a/js/utils/theme.js
+++ b/js/utils/theme.js
@@ -117,51 +117,63 @@ export class ThemeManager {
             
             /* テーマ別スタイル（ダークモード） */
             .dark-theme .grid-theme-item.theme-default {
-                background-color: #1a1a1a;
+                background-color: #2a2a2a;
+                border: 1px solid rgba(255, 255, 255, 0.1);
             }
             
             .dark-theme .grid-theme-item.theme-warm {
-                background-color: #2d1810;
+                background-color: #3d2820;
+                border: 1px solid rgba(255, 139, 37, 0.2);
             }
             
             .dark-theme .grid-theme-item.theme-cool {
-                background-color: #101828;
+                background-color: #202838;
+                border: 1px solid rgba(6, 182, 212, 0.2);
             }
             
             .dark-theme .grid-theme-item.theme-nature {
-                background-color: #0a1f0a;
+                background-color: #1a2f1a;
+                border: 1px solid rgba(16, 185, 129, 0.2);
             }
             
             .dark-theme .grid-theme-item.theme-elegant {
-                background-color: #1f0a2d;
+                background-color: #2f1a3d;
+                border: 1px solid rgba(139, 92, 246, 0.2);
             }
             
             .dark-theme .grid-theme-item.theme-modern {
-                background-color: #0f0f0f;
+                background-color: #1f1f1f;
+                border: 1px solid rgba(255, 255, 255, 0.1);
             }
             
             .dark-theme .photo-theme-item.theme-default {
-                background-color: #1a1a1a;
+                background-color: #2a2a2a;
+                border: 1px solid rgba(255, 255, 255, 0.1);
             }
             
             .dark-theme .photo-theme-item.theme-warm {
-                background-color: #2d1810;
+                background-color: #3d2820;
+                border: 1px solid rgba(255, 139, 37, 0.2);
             }
             
             .dark-theme .photo-theme-item.theme-cool {
-                background-color: #101828;
+                background-color: #202838;
+                border: 1px solid rgba(6, 182, 212, 0.2);
             }
             
             .dark-theme .photo-theme-item.theme-nature {
-                background-color: #0a1f0a;
+                background-color: #1a2f1a;
+                border: 1px solid rgba(16, 185, 129, 0.2);
             }
             
             .dark-theme .photo-theme-item.theme-elegant {
-                background-color: #1f0a2d;
+                background-color: #2f1a3d;
+                border: 1px solid rgba(139, 92, 246, 0.2);
             }
             
             .dark-theme .photo-theme-item.theme-modern {
-                background-color: #0f0f0f;
+                background-color: #1f1f1f;
+                border: 1px solid rgba(255, 255, 255, 0.1);
             }
         `;
         document.head.appendChild(style);

--- a/styles/app.css
+++ b/styles/app.css
@@ -1025,17 +1025,38 @@ body {
 .chip-color-9 { background: #EC4899 !important; }
 .chip-color-10 { background: #10B981 !important; }
 
+/* Dark mode adjustments for better visibility */
+.dark-theme .chip-color-1 { background: #7c8ff0 !important; }
+.dark-theme .chip-color-2 { background: #f2a1fc !important; }
+.dark-theme .chip-color-3 { background: #5fb8ff !important; }
+.dark-theme .chip-color-4 { background: #51f088 !important; }
+.dark-theme .chip-color-5 { background: #fb7ea8 !important; }
+.dark-theme .chip-color-6 { background: #3edede !important; }
+.dark-theme .chip-color-7 { background: #ff9d42 !important; }
+.dark-theme .chip-color-8 { background: #17c7e5 !important; }
+.dark-theme .chip-color-9 { background: #ef59a8 !important; }
+.dark-theme .chip-color-10 { background: #1ecd8f !important; }
+
+/* Ensure text contrast in dark mode */
+.dark-theme .theme-chip {
+    color: rgba(0, 0, 0, 0.9);
+    font-weight: var(--font-semibold);
+}
+
 /* ダークモード対応 */
 .dark-theme .grid-theme-item.theme-default {
-    background-color: #1a1a1a;
+    background-color: #2a2a2a;
+    border: 1px solid rgba(255, 255, 255, 0.1);
 }
 
 .dark-theme .grid-theme-item.theme-warm {
-    background-color: #2d1810;
+    background-color: #3d2820;
+    border: 1px solid rgba(255, 139, 37, 0.2);
 }
 
 .dark-theme .grid-theme-item.theme-cool {
-    background-color: #101828;
+    background-color: #202838;
+    border: 1px solid rgba(6, 182, 212, 0.2);
 }
 
 .dark-theme .theme-chip {
@@ -1047,15 +1068,18 @@ body {
 }
 
 .dark-theme .grid-theme-item.theme-nature {
-    background-color: #0a1f0a;
+    background-color: #1a2f1a;
+    border: 1px solid rgba(16, 185, 129, 0.2);
 }
 
 .dark-theme .grid-theme-item.theme-elegant {
-    background-color: #1f0a2d;
+    background-color: #2f1a3d;
+    border: 1px solid rgba(139, 92, 246, 0.2);
 }
 
 .dark-theme .grid-theme-item.theme-modern {
-    background-color: #0f0f0f;
+    background-color: #1f1f1f;
+    border: 1px solid rgba(255, 255, 255, 0.1);
 }
 
 .dark-theme .theme-grid {
@@ -1063,12 +1087,14 @@ body {
 }
 
 .dark-theme .section-title-input {
-    background: rgba(255, 255, 255, 0.02); /* Even lighter in dark mode */
-    color: var(--text-secondary);
+    background: rgba(255, 255, 255, 0.08); /* More visible in dark mode */
+    color: var(--text-primary);
+    border: 1px solid rgba(255, 255, 255, 0.1);
 }
 
 .dark-theme .section-title-input:focus {
-    background: rgba(255, 255, 255, 0.04); /* Very subtle increase on focus */
+    background: rgba(255, 255, 255, 0.12); /* More noticeable on focus */
+    border-color: rgba(255, 139, 37, 0.3);
 }
 
 /* ===== アクションセクション ===== */

--- a/styles/shared.css
+++ b/styles/shared.css
@@ -224,27 +224,33 @@
 
 /* ダークモード対応 */
 .dark-theme .photo-theme-item.theme-default {
-    background-color: #1a1a1a;
+    background-color: #2a2a2a;
+    border: 1px solid rgba(255, 255, 255, 0.1);
 }
 
 .dark-theme .photo-theme-item.theme-warm {
-    background-color: #2d1810;
+    background-color: #3d2820;
+    border: 1px solid rgba(255, 139, 37, 0.2);
 }
 
 .dark-theme .photo-theme-item.theme-cool {
-    background-color: #101828;
+    background-color: #202838;
+    border: 1px solid rgba(6, 182, 212, 0.2);
 }
 
 .dark-theme .photo-theme-item.theme-nature {
-    background-color: #0a1f0a;
+    background-color: #1a2f1a;
+    border: 1px solid rgba(16, 185, 129, 0.2);
 }
 
 .dark-theme .photo-theme-item.theme-elegant {
-    background-color: #1f0a2d;
+    background-color: #2f1a3d;
+    border: 1px solid rgba(139, 92, 246, 0.2);
 }
 
 .dark-theme .photo-theme-item.theme-modern {
-    background-color: #0f0f0f;
+    background-color: #1f1f1f;
+    border: 1px solid rgba(255, 255, 255, 0.1);
 }
 
 .dark-theme .photo-theme-grid {


### PR DESCRIPTION
## Summary

This PR fixes dark mode visibility issues reported in #163.

## Changes

- Added lighter color variants for theme chips in dark mode
- Changed theme chip text to dark color with semibold weight for better contrast
- Increased grid theme item background lightness in dark mode
- Added subtle borders to grid items for better distinction
- Improved section title input visibility with better opacity and borders
- Enhanced focus states for inputs in dark mode

Closes #163

Generated with [Claude Code](https://claude.ai/code)