### PR TITLE
fix: remove space below header

### DIFF
--- a/styles/app.css
+++ b/styles/app.css
@@ -556,7 +556,7 @@ body {
     background: rgba(255, 255, 255, 0.9);
     backdrop-filter: blur(10px);
     padding: var(--spacing-4) 0;
-    margin-bottom: 18px;
+    margin-bottom: 0;
 }
 
 /* ダークモード時のヘッダー背景を黒に */


### PR DESCRIPTION
## Summary

Set the space below the header and the first component to 0 as requested in #172.

## Changes
- Updated `.app-header` CSS rule to set `margin-bottom: 0` (previously 18px)

🤖 Generated with [Claude Code](https://claude.ai/code)