### PR TITLE
feat: update grid UI with 6px margins and responsive layout

### DIFF
--- a/js/shared-grid-refactored.js
+++ b/js/shared-grid-refactored.js
@@ -77,6 +77,9 @@ import { toast, modal, share, GridRenderer, StorageManager, theme } from './util
             
             // 既に画像がアップロードされている場合
             if (state.uploadedImages[index]) {
+                // has-imageクラスを追加
+                gridItem.classList.add('has-image');
+                
                 // 画像を表示
                 const img = document.createElement('img');
                 img.className = 'uploaded-image';

--- a/js/shared-grid.js
+++ b/js/shared-grid.js
@@ -218,6 +218,9 @@
         img.alt = `アップロードされた画像 ${index + 1}`;
         
         flipCardFront.appendChild(img);
+        
+        // has-imageクラスを追加
+        photoArea.classList.add('has-image');
     }
     
     // アップロードモーダルを閉じる

--- a/styles/app.css
+++ b/styles/app.css
@@ -785,13 +785,13 @@ body {
 /* ===== テーマグリッド ===== */
 .theme-grid {
     display: grid;
-    gap: var(--spacing-4);
+    gap: 6px;
     aspect-ratio: 1;
-    max-width: 800px;
-    width: 100%;
+    max-width: 780px;
+    width: calc(100% - 32px);
     margin: 0 auto;
     background: var(--bg-secondary);
-    padding: var(--spacing-6);
+    padding: 6px;
     border-radius: var(--radius-xl);
     box-shadow: var(--shadow-xl);
 }
@@ -807,6 +807,7 @@ body {
     justify-content: center;
     padding: var(--spacing-3);
     min-height: 100px;
+    aspect-ratio: 1;
 }
 
 .grid-theme-item:hover {
@@ -1349,9 +1350,10 @@ body {
     }
     
     .theme-grid {
-        max-width: 90%;
-        padding: var(--spacing-4);
-        gap: var(--spacing-3);
+        max-width: 780px;
+        width: calc(100% - 32px);
+        padding: 6px;
+        gap: 6px;
     }
     
     .action-buttons {
@@ -1366,8 +1368,10 @@ body {
 
 @media (max-width: 480px) {
     .theme-grid {
-        gap: var(--spacing-2);
-        padding: var(--spacing-3);
+        gap: 6px;
+        padding: 6px;
+        width: calc(100% - 32px);
+        max-width: 780px;
     }
     
     .theme-input {

--- a/styles/shared.css
+++ b/styles/shared.css
@@ -37,13 +37,13 @@
 /* ===== フォトテーマグリッド ===== */
 .theme-grid {
     display: grid;
-    gap: var(--spacing-4);
+    gap: 6px;
     aspect-ratio: 1;
-    max-width: 800px;
-    width: 100%;
+    max-width: 780px;
+    width: calc(100% - 32px);
     margin: 0 auto;
     background: var(--bg-secondary);
-    padding: var(--spacing-6);
+    padding: 6px;
     border-radius: var(--radius-xl);
     box-shadow: var(--shadow-xl);
 }
@@ -58,8 +58,9 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    padding: var(--spacing-3);
+    padding: 0;
     min-height: 100px;
+    aspect-ratio: 1;
 }
 
 .grid-theme-item:hover {
@@ -76,6 +77,7 @@
     justify-content: center;
     flex-direction: column;
     position: relative;
+    padding: 0;
 }
 
 /* 共有セクションタイトル */
@@ -114,10 +116,10 @@
 .photo-display-area {
     position: relative;
     width: 100%;
-    aspect-ratio: 1;
+    height: 100%;
     background: rgba(0, 0, 0, 0.05);
     border: 2px dashed rgba(0, 0, 0, 0.2);
-    border-radius: var(--radius-md);
+    border-radius: var(--radius-lg);
     display: flex;
     align-items: center;
     justify-content: center;
@@ -125,6 +127,11 @@
     transition: all var(--transition-base);
     overflow: hidden;
     perspective: 1000px;
+}
+
+.photo-display-area.has-image {
+    border: none;
+    background: none;
 }
 
 .photo-display-area:hover {
@@ -182,7 +189,7 @@
     width: 100%;
     height: 100%;
     object-fit: cover;
-    border-radius: var(--radius-md);
+    border-radius: var(--radius-lg);
 }
 
 /* テーマテキスト（カードの裏面） */
@@ -321,16 +328,21 @@
 
 .grid-menu-button {
     position: absolute;
-    top: var(--spacing-2);
-    right: var(--spacing-2);
+    top: 8px;
+    right: 8px;
     background: rgba(0, 0, 0, 0.6);
     border: none;
     border-radius: var(--radius-full);
-    padding: var(--spacing-1);
+    padding: 6px;
     cursor: pointer;
     color: white;
     transition: all var(--transition-base);
     z-index: 10;
+    width: 32px;
+    height: 32px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 }
 
 .grid-menu-button:hover {
@@ -343,7 +355,7 @@
     width: 100%;
     height: 100%;
     object-fit: cover;
-    border-radius: var(--radius-md);
+    border-radius: var(--radius-lg);
     position: absolute;
     top: 0;
     left: 0;
@@ -419,9 +431,10 @@
 /* ===== レスポンシブ ===== */
 @media (max-width: 768px) {
     .theme-grid {
-        max-width: 90%;
-        padding: var(--spacing-4);
-        gap: var(--spacing-3);
+        max-width: 780px;
+        width: calc(100% - 32px);
+        padding: 6px;
+        gap: 6px;
     }
     
     .shared-actions {
@@ -437,8 +450,10 @@
 
 @media (max-width: 480px) {
     .theme-grid {
-        gap: var(--spacing-2);
-        padding: var(--spacing-3);
+        gap: 6px;
+        padding: 6px;
+        width: calc(100% - 32px);
+        max-width: 780px;
     }
     
     .grid-theme-text {


### PR DESCRIPTION
## Description

This PR updates the grid UI according to the specifications in #173:

- Set grid margins to 6px (from var(--spacing-4))
- Set grid width to 780px with 16px side margins
- Implement responsive behavior maintaining 16px margins at all sizes
- Add aspect-ratio: 1 to ensure square grid items
- Remove padding from shared section grid items for full photo display
- Add .has-image class to remove borders when photos are uploaded
- Position menu icons as overlays at top-right (8px, 8px)
- Update border-radius consistency across uploaded images

Fixes #173

Generated with [Claude Code](https://claude.ai/code)