### PR TITLE
fix: change default grid background color to orange

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@
                     <!-- グリッド背景色選択 -->
                     <div class="grid-bg-color-selector">
                         <label for="grid-bg-color">背景色:</label>
-                        <input type="color" id="grid-bg-color" class="color-input" value="#000000">
+                        <input type="color" id="grid-bg-color" class="color-input" value="#FF8B25">
                     </div>
                 </div>
                 

--- a/js/photo-grid-refactored.js
+++ b/js/photo-grid-refactored.js
@@ -15,7 +15,7 @@ import { toast, modal, storage, share, GridRenderer, theme } from './utils/index
         gridSections: [],
         saveTimeout: null,
         currentFocusedInput: null,
-        gridBgColor: '#000000' // デフォルトは黒
+        gridBgColor: '#FF8B25' // デフォルトは黒
     };
     
     // テーマサジェスチョンのリスト
@@ -283,7 +283,7 @@ import { toast, modal, storage, share, GridRenderer, theme } from './utils/index
         
         if (savedData) {
             state.gridSize = savedData.size || 3;
-            state.gridBgColor = savedData.bgColor || '#000000';
+            state.gridBgColor = savedData.bgColor || '#FF8B25';
             
             // グリッドサイズセレクトを更新
             if (elements.gridSizeSelect) {

--- a/js/photo-grid.js
+++ b/js/photo-grid.js
@@ -13,7 +13,7 @@
         gridSections: [], // グリッドセクションを格納
         saveTimeout: null,
         currentFocusedInput: null, // 現在フォーカスされている入力フィールド
-        gridBgColor: '#000000' // グリッド背景色のデフォルト値
+        gridBgColor: '#FF8B25' // グリッド背景色のデフォルト値
     };
     
     // テーマサジェスチョンのリスト

--- a/js/shared-grid-refactored.js
+++ b/js/shared-grid-refactored.js
@@ -14,7 +14,7 @@ import { toast, modal, share, GridRenderer, StorageManager, theme } from './util
         gridSize: 2,
         gridSections: [],
         uploadedImages: {},
-        gridBgColor: '#000000' // デフォルトは黒
+        gridBgColor: '#FF8B25' // デフォルトは黒
     };
     
     // StorageManagerのインスタンスを作成
@@ -145,7 +145,7 @@ import { toast, modal, share, GridRenderer, StorageManager, theme } from './util
         
         state.gridSize = sharedData.size || 2;
         state.gridSections = sharedData.sections || [];
-        state.gridBgColor = sharedData.bgColor || '#000000';
+        state.gridBgColor = sharedData.bgColor || '#FF8B25';
         
         // 背景色入力を更新
         if (elements.gridBgColorInput) {

--- a/js/shared-grid.js
+++ b/js/shared-grid.js
@@ -12,7 +12,7 @@
         gridSize: 2,
         gridSections: [],
         uploadedImages: {}, // インデックスをキーとして画像を保存
-        gridBgColor: '#000000' // グリッド背景色のデフォルト値
+        gridBgColor: '#FF8B25' // グリッド背景色のデフォルト値
     };
     
     // DOM要素
@@ -53,7 +53,7 @@
         
         state.gridSize = sharedData.size || 2;
         state.gridSections = sharedData.sections || [];
-        state.gridBgColor = sharedData.bgColor || '#000000';
+        state.gridBgColor = sharedData.bgColor || '#FF8B25';
         
         // グリッドHTMLの生成
         elements.photoThemeGrid.innerHTML = '';

--- a/shared.html
+++ b/shared.html
@@ -42,7 +42,7 @@
                 <!-- グリッド背景色選択 -->
                 <div class="grid-bg-color-selector shared-color-selector">
                     <label for="grid-bg-color">背景色:</label>
-                    <input type="color" id="grid-bg-color" class="color-input" value="#000000">
+                    <input type="color" id="grid-bg-color" class="color-input" value="#FF8B25">
                 </div>
                 
                 <!-- フォトグリッド -->


### PR DESCRIPTION
## Summary
- Changed default grid background color from black to orange (#FF8B25)
- Updated all relevant HTML and JavaScript files
- Now matches the button color scheme

Closes #175

Generated with [Claude Code](https://claude.ai/code)