### PR TITLE
feat: 共有画面のダウンロードとInstagram Stories共有ボタンを統合

### DIFF
--- a/js/shared-grid.js
+++ b/js/shared-grid.js
@@ -18,9 +18,12 @@
     // DOM要素
     const elements = {
         photoThemeGrid: document.getElementById('photo-theme-grid'),
+        mainShareBtn: document.getElementById('main-share-btn'),
         downloadBtn: document.getElementById('download-grid-btn'),
-        shareInstagramBtn: document.getElementById('share-instagram-stories-btn'),
-        gridBgColorInput: document.getElementById('grid-bg-color-input')
+        shareInstagramBtn: document.getElementById('share-instagram-btn'),
+        gridBgColorInput: document.getElementById('grid-bg-color-input'),
+        shareModal: document.getElementById('share-modal'),
+        shareModalClose: null
     };
     
     // URLパラメータからデータを取得
@@ -247,6 +250,20 @@
         }
     }
     
+    // 共有モーダルを表示
+    function showShareModal() {
+        if (elements.shareModal) {
+            elements.shareModal.classList.add('active');
+        }
+    }
+    
+    // 共有モーダルを閉じる
+    function closeShareModal() {
+        if (elements.shareModal) {
+            elements.shareModal.classList.remove('active');
+        }
+    }
+    
     // Instagram Stories共有機能
     function shareInstagramStories() {
         // html2canvasライブラリを使用してグリッドをキャプチャ
@@ -360,12 +377,25 @@
     
     // イベントリスナーの設定
     function setupEventListeners() {
-        if (elements.downloadBtn) {
-            elements.downloadBtn.addEventListener('click', downloadGrid);
+        // 共有ボタン
+        if (elements.mainShareBtn) {
+            elements.mainShareBtn.addEventListener('click', showShareModal);
         }
         
+        // ダウンロードボタン（モーダル内）
+        if (elements.downloadBtn) {
+            elements.downloadBtn.addEventListener('click', () => {
+                downloadGrid();
+                closeShareModal();
+            });
+        }
+        
+        // Instagram Storiesボタン（モーダル内）
         if (elements.shareInstagramBtn) {
-            elements.shareInstagramBtn.addEventListener('click', shareInstagramStories);
+            elements.shareInstagramBtn.addEventListener('click', () => {
+                shareInstagramStories();
+                closeShareModal();
+            });
         }
         
         // カラーピッカーのイベント
@@ -373,7 +403,25 @@
             elements.gridBgColorInput.addEventListener('input', handleBgColorChange);
         }
         
-        // モーダル関連のイベント
+        // 共有モーダル関連
+        if (elements.shareModal) {
+            // モーダルの閉じるボタンを取得
+            elements.shareModalClose = elements.shareModal.querySelector('.app-modal-close');
+            
+            // モーダルを閉じる
+            if (elements.shareModalClose) {
+                elements.shareModalClose.addEventListener('click', closeShareModal);
+            }
+            
+            // モーダル背景クリックで閉じる
+            elements.shareModal.addEventListener('click', (e) => {
+                if (e.target === elements.shareModal) {
+                    closeShareModal();
+                }
+            });
+        }
+        
+        // アップロードモーダル関連のイベント
         const modal = document.getElementById('upload-modal');
         const modalClose = modal.querySelector('.app-modal-close');
         const uploadArea = document.getElementById('upload-area');

--- a/shared.html
+++ b/shared.html
@@ -52,19 +52,13 @@
                 
                 <!-- アクションボタン -->
                 <div class="shared-actions">
-                    <button class="btn-secondary" id="download-grid-btn">
-                        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                            <path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/>
-                            <polyline points="7 10 12 15 17 10"/>
-                            <line x1="12" y1="15" x2="12" y2="3"/>
+                    <button class="btn-primary btn-lg" id="main-share-btn">
+                        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="margin-right: 8px;">
+                            <path d="M4 12v8a2 2 0 002 2h12a2 2 0 002-2v-8"/>
+                            <polyline points="16 6 12 2 8 6"/>
+                            <line x1="12" y1="2" x2="12" y2="15"/>
                         </svg>
-                        グリッドをダウンロード
-                    </button>
-                    <button class="btn-secondary" id="share-instagram-stories-btn">
-                        <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
-                            <path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zM5.838 12a6.162 6.162 0 1112.324 0 6.162 6.162 0 01-12.324 0zM12 16a4 4 0 110-8 4 4 0 010 8zm4.965-10.405a1.44 1.44 0 112.881.001 1.44 1.44 0 01-2.881-.001z"/>
-                        </svg>
-                        Instagram Storiesで共有
+                        グリッドを共有
                     </button>
                 </div>
             </section>
@@ -99,6 +93,39 @@
                     </svg>
                     <p>クリックまたはドラッグ＆ドロップで画像をアップロード</p>
                     <input type="file" id="file-input" accept="image/*" style="display: none;">
+                </div>
+            </div>
+        </div>
+    </div>
+    
+    <!-- 共有モーダル -->
+    <div class="app-modal" id="share-modal">
+        <div class="app-modal-content card-glass" style="max-width: 400px;">
+            <div class="app-modal-header">
+                <h3>グリッドを共有</h3>
+                <button class="btn-icon app-modal-close" aria-label="閉じる">
+                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <line x1="18" y1="6" x2="6" y2="18"/>
+                        <line x1="6" y1="6" x2="18" y2="18"/>
+                    </svg>
+                </button>
+            </div>
+            <div class="app-modal-body">
+                <div class="share-options">
+                    <button class="share-option-btn" id="download-grid-btn">
+                        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/>
+                            <polyline points="7 10 12 15 17 10"/>
+                            <line x1="12" y1="15" x2="12" y2="3"/>
+                        </svg>
+                        <span>グリッドをダウンロード</span>
+                    </button>
+                    <button class="share-option-btn" id="share-instagram-btn">
+                        <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+                            <path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zM5.838 12a6.162 6.162 0 1112.324 0 6.162 6.162 0 01-12.324 0zM12 16a4 4 0 110-8 4 4 0 010 8zm4.965-10.405a1.44 1.44 0 112.881.001 1.44 1.44 0 01-2.881-.001z"/>
+                        </svg>
+                        <span>Instagram Stories</span>
+                    </button>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- 共有画面の2つのボタンを統合して、indexページと同様の共有ボタンに変更
- クリック時にモーダルでメニューを表示

## Changes
- shared.html: 共有モーダルを追加し、2つのボタンを1つに統合
- js/shared-grid.js: モーダルの表示/非表示機能を実装

Closes #181

🤖 Generated with [Claude Code](https://claude.ai/code)