### PR TITLE
fix: remove spacing above grid widgets

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
                 </div>
                 
                 <!-- テーマ説明テキスト -->
-                <div style="text-align: center; margin-bottom: 8px;">
+                <div style="text-align: center; margin-bottom: 0;">
                     <p style="font-size: 12px; color: gray; margin: 0;">グリッドのテーマは自由に変更できるよ！</p>
                 </div>
                 

--- a/styles/app.css
+++ b/styles/app.css
@@ -711,7 +711,7 @@ body {
     align-items: center;
     justify-content: center;
     gap: var(--spacing-8);
-    margin-bottom: var(--spacing-6);
+    margin-bottom: 0;
     flex-wrap: wrap;
 }
 
@@ -942,7 +942,7 @@ body {
 /* テーマサジェスチョンチップス */
 .theme-suggestions-container {
     margin-top: var(--spacing-4);
-    margin-bottom: var(--spacing-6);
+    margin-bottom: 0;
     overflow: hidden;
     position: relative;
     width: 100vw;

--- a/styles/shared.css
+++ b/styles/shared.css
@@ -16,7 +16,7 @@
 .shared-subtitle {
     font-size: var(--text-lg);
     color: var(--text-secondary);
-    margin-bottom: var(--spacing-10);
+    margin-bottom: 0;
 }
 
 /* ===== 共有ページの背景色セレクター ===== */


### PR DESCRIPTION
## Summary
- Removed margin spacing above grid widgets on all pages
- Set margin-bottom to 0 for grid controls, theme suggestions, and subtitles
- This reduces the distance between the header and grid widgets as requested

Closes #183

🤖 Generated with [Claude Code](https://claude.ai/code)