### PR TITLE
Fix: デフォルトグリッドサイズを3x3に統一

### DIFF
--- a/js/photo-grid.js
+++ b/js/photo-grid.js
@@ -9,7 +9,7 @@
     
     // 状態管理
     const state = {
-        gridSize: 2, // デフォルトを2x2に設定
+        gridSize: 3, // デフォルトを3x3に設定
         gridSections: [], // グリッドセクションを格納
         saveTimeout: null,
         currentFocusedInput: null, // 現在フォーカスされている入力フィールド


### PR DESCRIPTION
Fixes !85

## Summary
- JavaScriptのデフォルトグリッドサイズを2から3に変更
- HTMLドロップダウンのデフォルト値（3x3）と一致させる
- グリッド表示とドロップダウンの不整合を解消

Generated with [Claude Code](https://claude.ai/code)