### PR TITLE
feat: integrate shared photo grid into main page

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
     <link rel="stylesheet" href="styles/design-tokens.css">
     <link rel="stylesheet" href="styles/components.css">
     <link rel="stylesheet" href="styles/app.css">
+    <link rel="stylesheet" href="styles/shared.css">
 </head>
 <body>
     <!-- ヘッダー -->
@@ -86,6 +87,17 @@
                         </svg>
                         GridMeを共有
                     </button>
+                </div>
+
+                <!-- 共有グリッドセクション -->
+                <div class="shared-grid-section">
+                    <h2 class="shared-title">共有されたテーマグリッド</h2>
+                    <p class="shared-subtitle">各テーマに合った写真を追加してください</p>
+                    
+                    <!-- フォトグリッド -->
+                    <div class="theme-grid" id="photo-theme-grid">
+                        <!-- 動的に生成されます -->
+                    </div>
                 </div>
 
             </section>


### PR DESCRIPTION
## Summary

Integrated the shared photo grid functionality from the shared page into the main page, positioned between the share button and the main grid.

## Changes
- Added shared grid section to index.html
- Imported shared.css for proper styling
- Extended photo-grid.js with comprehensive photo grid functionality
- Photo upload support with drag & drop
- Real-time synchronization with theme changes
- Persistent storage of uploaded images

Closes #187

🤖 Generated with [Claude Code](https://claude.ai/code)