### PR TITLE
fix: 共有URL読み込みエラーを修正

### DIFF
--- a/js/photo-grid.js
+++ b/js/photo-grid.js
@@ -247,7 +247,13 @@
             bgColor: state.gridBgColor
         };
         
-        const encodedData = btoa(unescape(encodeURIComponent(JSON.stringify(shareData))));
+        // UTF-8文字列をBase64エンコード
+        const jsonString = JSON.stringify(shareData);
+        const utf8Bytes = encodeURIComponent(jsonString).replace(/%([0-9A-F]{2})/g,
+            function(match, p1) {
+                return String.fromCharCode('0x' + p1);
+            });
+        const encodedData = btoa(utf8Bytes);
         return `${window.location.origin}${window.location.pathname.replace('index.html', '')}shared.html?data=${encodedData}`;
     }
     

--- a/js/shared-grid.js
+++ b/js/shared-grid.js
@@ -40,9 +40,12 @@
         }
         
         try {
-            // photo-grid.jsでのエンコード: btoa(unescape(encodeURIComponent(JSON.stringify(shareData))))
-            // 対応するデコード: JSON.parse(decodeURIComponent(escape(atob(encodedData))))
-            const decodedString = decodeURIComponent(escape(atob(encodedData)));
+            // Base64デコード後、UTF-8として解釈
+            const decodedBase64 = atob(encodedData);
+            // UTF-8バイト列を文字列に変換
+            const decodedString = decodeURIComponent(decodedBase64.split('').map(function(c) {
+                return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2);
+            }).join(''));
             return JSON.parse(decodedString);
         } catch (err) {
             console.error('データのデコードエラー:', err);

--- a/js/utils/share.js
+++ b/js/utils/share.js
@@ -123,8 +123,13 @@ export class ShareManager {
     // 共有データのエンコード
     encodeShareData(data) {
         try {
+            // UTF-8文字列をBase64エンコード
             const jsonString = JSON.stringify(data);
-            return btoa(unescape(encodeURIComponent(jsonString)));
+            const utf8Bytes = encodeURIComponent(jsonString).replace(/%([0-9A-F]{2})/g,
+                function(match, p1) {
+                    return String.fromCharCode('0x' + p1);
+                });
+            return btoa(utf8Bytes);
         } catch (error) {
             console.error('Share data encode error:', error);
             return null;
@@ -134,8 +139,13 @@ export class ShareManager {
     // 共有データのデコード
     decodeShareData(encodedData) {
         try {
-            const jsonString = decodeURIComponent(escape(atob(encodedData)));
-            return JSON.parse(jsonString);
+            // Base64デコード後、UTF-8として解釈
+            const decodedBase64 = atob(encodedData);
+            // UTF-8バイト列を文字列に変換
+            const decodedString = decodeURIComponent(decodedBase64.split('').map(function(c) {
+                return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2);
+            }).join(''));
+            return JSON.parse(decodedString);
         } catch (error) {
             console.error('Share data decode error:', error);
             return null;


### PR DESCRIPTION
## 概要

シェアURLを踏むと発生するエラーを修正しました。

## 変更内容

- JavaScriptの廃止予定関数`escape`と`unescape`をモダンなUTF-8エンコード/デコード方式に置き換え
- shared-grid.jsのgetSharedData関数のデコード処理を修正
- photo-grid.jsのgenerateShareUrl関数のエンコード処理を修正
- utils/share.jsのencodeShareData/decodeShareData関数も同様に修正

Closes #189

Generated with [Claude Code](https://claude.ai/code)