### PR TITLE
fix: adjust margin and text background color in theme grid

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@
                 </div>
                 
                 <!-- テーマ説明テキスト -->
-                <div style="text-align: center; margin-bottom: 0;">
+                <div style="text-align: center; margin-bottom: 6px;">
                     <p style="font-size: 12px; color: gray; margin: 0;">グリッドのテーマは自由に変更できるよ！</p>
                 </div>
                 

--- a/styles/app.css
+++ b/styles/app.css
@@ -840,7 +840,7 @@ body {
     font-weight: var(--font-normal);
     font-family: inherit;
     transition: all var(--transition-base);
-    background: rgba(0, 0, 0, 0.03); /* Lighter gray background */
+    background: white; /* Pure white background */
     color: var(--text-secondary);
     resize: none;
     overflow: hidden;
@@ -855,7 +855,7 @@ body {
 .section-title-input:focus {
     outline: none;
     box-shadow: none;
-    background: rgba(0, 0, 0, 0.05); /* Slightly darker on focus */
+    background: white; /* Keep white background on focus */
 }
 
 /* セクションテーマ選択 */
@@ -1094,13 +1094,13 @@ body {
 }
 
 .dark-theme .section-title-input {
-    background: rgba(255, 255, 255, 0.08); /* More visible in dark mode */
-    color: var(--text-primary);
+    background: white; /* Pure white background in dark mode */
+    color: var(--text-secondary);
     border: 1px solid rgba(255, 255, 255, 0.1);
 }
 
 .dark-theme .section-title-input:focus {
-    background: rgba(255, 255, 255, 0.12); /* More noticeable on focus */
+    background: white; /* Keep white background on focus */
     border-color: rgba(255, 139, 37, 0.3);
 }
 


### PR DESCRIPTION
## Summary

This PR addresses the styling adjustments requested in #191:

1. Added 6px margin between the descriptive text and the theme grid
2. Changed the background color of text inputs inside grid theme frames to pure white

## Changes

- Updated `index.html` to add 6px bottom margin to the descriptive text container
- Modified `styles/app.css` to change `.section-title-input` background from gray to pure white
- Ensured white background is maintained in both light and dark themes

Closes #191

Generated with [Claude Code](https://claude.ai/code)