### PR TITLE
fix: ダークモードでメインコンテンツの色を正しく表示

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@
                 
                 <!-- テーマ説明テキスト -->
                 <div style="text-align: center; margin-bottom: 6px;">
-                    <p style="font-size: 12px; color: gray; margin: 0;">グリッドのテーマは自由に変更できるよ！</p>
+                    <p style="font-size: 12px; color: var(--text-secondary); margin: 0;">グリッドのテーマは自由に変更できるよ！</p>
                 </div>
                 
                 <!-- テーマグリッド -->

--- a/styles/app.css
+++ b/styles/app.css
@@ -703,6 +703,7 @@ body {
     justify-content: center;
     min-height: calc(100vh - 200px);
     padding: 0 0 var(--spacing-4) 0;
+    background: var(--bg-primary);
 }
 
 /* ===== グリッドコントロール ===== */
@@ -1467,5 +1468,80 @@ body {
 
 .dark-theme .share-url-preview {
     border-color: var(--neutral-700);
+}
+
+/* ===== 追加のダークモード対応 ===== */
+
+/* メインコンテンツ領域のダークモード */
+@media (prefers-color-scheme: dark) {
+    /* 基本要素 */
+    body {
+        background: var(--bg-primary);
+        color: var(--text-primary);
+    }
+    
+    /* セクション */
+    .section {
+        background: var(--bg-primary);
+        color: var(--text-primary);
+    }
+    
+    /* タイトル要素 */
+    .section-title,
+    .theme-title,
+    .grid-title {
+        color: var(--text-primary);
+    }
+    
+    /* コンポーネントデモ */
+    .component-demo {
+        background: var(--card-bg);
+        border: 1px solid var(--card-border);
+    }
+    
+    /* モックアップ要素 */
+    .mock-browser,
+    .mock-phone,
+    .mock-dashboard {
+        background: var(--card-bg);
+        border: 1px solid var(--card-border);
+    }
+    
+    .mini-card {
+        background: var(--bg-secondary);
+    }
+    
+    /* メインセクション */
+    .app-main,
+    .grid-main-section,
+    .photo-grid-section,
+    .theme-input-section {
+        background: var(--bg-primary);
+        color: var(--text-primary);
+    }
+    
+    /* テーマ入力カード */
+    .theme-input-card {
+        background: var(--card-bg);
+        border: 1px solid var(--card-border);
+    }
+    
+    /* テーマ説明テキスト */
+    .grid-main-section p {
+        color: var(--text-secondary) !important;
+    }
+    
+    /* サジェスチョンチップ */
+    .suggestion-chip {
+        background: var(--neutral-800);
+        border-color: var(--neutral-700);
+        color: var(--neutral-100);
+    }
+    
+    .suggestion-chip:hover {
+        background: var(--primary-solid);
+        color: white;
+        border-color: transparent;
+    }
 }
 

--- a/styles/shared.css
+++ b/styles/shared.css
@@ -313,6 +313,43 @@
     background: var(--bg-secondary);
 }
 
+/* ===== 追加のダークモード対応 ===== */
+@media (prefers-color-scheme: dark) {
+    /* 共有グリッドセクション */
+    .shared-grid-section {
+        background: var(--bg-primary);
+        color: var(--text-primary);
+    }
+    
+    .shared-title {
+        color: var(--text-primary);
+    }
+    
+    .shared-subtitle {
+        color: var(--text-secondary);
+    }
+    
+    /* テーマテキスト */
+    .theme-text {
+        color: var(--text-primary);
+    }
+    
+    /* セクションタイトル */
+    .shared-section-title {
+        color: var(--text-primary);
+    }
+    
+    /* セクションコンテンツ */
+    .shared-section-content {
+        color: var(--text-secondary);
+    }
+    
+    /* グリッドテーマテキスト */
+    .grid-theme-text {
+        color: var(--text-primary);
+    }
+}
+
 /* ===== グリッドテーマテキスト ===== */
 .grid-theme-text {
     font-size: var(--text-base);


### PR DESCRIPTION
## Summary
- ダークモードでメインコンテンツが適切に表示されるように修正
- 全てのメインコンテンツ要素がCSS変数を使用して自動的にダークモードに対応

## Test plan
- [ ] ブラウザのダークモードを有効にして、メインコンテンツが正しく表示されることを確認
- [ ] ライトモードでも正常に動作することを確認
- [ ] テキストが読みやすいコントラストで表示されることを確認

Closes #199

🤖 Generated with [Claude Code](https://claude.ai/code)