### PR TITLE
fix: ロゴサイズと42pxに変更し、ヘッダーとメインコンテンツの余白を最小化

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
         <div class="container">
             <div class="header-content">
                 <h1 class="app-title">
-                    <img src="assets/logos/GridMe_logo.png" alt="GridMe" style="height: 32px; vertical-align: middle;">
+                    <img src="assets/logos/GridMe_logo.png" alt="GridMe" style="height: 42px; vertical-align: middle;">
                 </h1>
             </div>
         </div>

--- a/shared.html
+++ b/shared.html
@@ -24,7 +24,7 @@
             <div class="header-content">
                 <h1 class="app-title">
                     <a href="./index.html" style="text-decoration: none;">
-                        <img src="assets/logos/GridMe_logo.png" alt="GridMe" style="height: 32px; vertical-align: middle;">
+                        <img src="assets/logos/GridMe_logo.png" alt="GridMe" style="height: 42px; vertical-align: middle;">
                     </a>
                 </h1>
             </div>

--- a/styles/app.css
+++ b/styles/app.css
@@ -555,7 +555,7 @@ body {
 .app-header {
     background: rgba(255, 255, 255, 0.9);
     backdrop-filter: blur(10px);
-    padding: var(--spacing-2) 0;
+    padding: var(--spacing-1) 0;
     margin-bottom: 0;
 }
 
@@ -600,7 +600,7 @@ body {
 }
 
 .app-main {
-    padding-top: var(--spacing-4);
+    padding-top: var(--spacing-1);
     padding-bottom: var(--spacing-8);
     min-height: calc(100vh - 160px);
 }


### PR DESCRIPTION
## Summary
- ロゴの高さを32pxから42pxに更新
- ヘッダーとメインコンテンツの間の余白を大幅に削減

## Test plan
- [ ] ブラウザでロゴが42pxで表示されることを確認
- [ ] ヘッダーとメインコンテンツの間の余白が狭くなっていることを確認
- [ ] ダークモードでも正しく表示されることを確認

Closes #213

🤖 Generated with [Claude Code](https://claude.ai/code)