### PR TITLE
fix: SVG要素のclassName設定エラーを修正

### DIFF
--- a/js/shared-grid.js
+++ b/js/shared-grid.js
@@ -114,7 +114,7 @@
         
         // プラスアイコン
         const addPhotoIcon = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
-        addPhotoIcon.className = 'add-photo-icon';
+        addPhotoIcon.setAttribute('class', 'add-photo-icon');
         addPhotoIcon.setAttribute('viewBox', '0 0 24 24');
         addPhotoIcon.setAttribute('fill', 'none');
         addPhotoIcon.setAttribute('stroke', 'currentColor');


### PR DESCRIPTION
## 概要

shared-grid.jsで発生していたSVG要素のエラーを修正しました。

## 変更内容
- SVG要素にはclassNameプロパティではなくsetAttribute('class', ...)を使用するように修正

Fixes #214

Generated with [Claude Code](https://claude.ai/code)