### PR TITLE
fix: adjust spacing between GridMe button and theme chips to 16px

### DIFF
--- a/styles/app.css
+++ b/styles/app.css
@@ -786,7 +786,7 @@ body {
 /* ===== 共有ボタンコンテナ ===== */
 .share-button-container {
     margin-top: var(--spacing-8);
-    margin-bottom: var(--spacing-8);
+    margin-bottom: var(--spacing-4);
 }
 
 /* ===== テーマグリッド ===== */
@@ -942,7 +942,7 @@ body {
 
 /* テーマサジェスチョンチップス */
 .theme-suggestions-container {
-    margin-top: var(--spacing-4);
+    margin-top: 0;
     margin-bottom: 0;
     overflow: hidden;
     position: relative;

--- a/styles/shared.css
+++ b/styles/shared.css
@@ -475,6 +475,7 @@
     display: flex;
     justify-content: center;
     gap: var(--spacing-4);
+    margin-top: var(--spacing-4);
 }
 
 /* ===== レスポンシブ ===== */


### PR DESCRIPTION
## Summary
- Fixed excessive spacing on index page between GridMe button and theme chips
- Added missing spacing on shared page between grid and share button
- Both pages now have consistent 16px spacing as requested

## Test plan
- [ ] View index.html and verify 16px gap between GridMe button and theme chips
- [ ] View shared.html and verify 16px gap between grid and share button
- [ ] Test on different screen sizes to ensure responsive behavior

Fixes #218

🤖 Generated with [Claude Code](https://claude.ai/code)