### PR TITLE
feat: ロゴに6pxの上部マージンを追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
         <div class="container">
             <div class="header-content">
                 <h1 class="app-title">
-                    <img src="assets/logos/GridMe_logo.png" alt="GridMe" style="height: 42px; vertical-align: middle;">
+                    <img src="assets/logos/GridMe_logo.png" alt="GridMe" style="height: 42px; vertical-align: middle; margin-top: 6px;">
                 </h1>
             </div>
         </div>

--- a/shared.html
+++ b/shared.html
@@ -24,7 +24,7 @@
             <div class="header-content">
                 <h1 class="app-title">
                     <a href="./index.html" style="text-decoration: none;">
-                        <img src="assets/logos/GridMe_logo.png" alt="GridMe" style="height: 42px; vertical-align: middle;">
+                        <img src="assets/logos/GridMe_logo.png" alt="GridMe" style="height: 42px; vertical-align: middle; margin-top: 6px;">
                     </a>
                 </h1>
             </div>


### PR DESCRIPTION
# 概要

ロゴに6pxの上部マージンを追加しました。

## 変更内容

- `index.html` と `shared.html` のロゴ画像に `margin-top: 6px` を追加
- ヘッダー内のロゴの位置を調整

Closes %23219

Generated with [Claude Code](https://claude.ai/code)