### PR TITLE
fix: update margin values for share button containers

### DIFF
--- a/styles/app.css
+++ b/styles/app.css
@@ -785,7 +785,7 @@ body {
 
 /* ===== 共有ボタンコンテナ ===== */
 .share-button-container {
-    margin-top: var(--spacing-8);
+    margin-top: 12px;
     margin-bottom: var(--spacing-4);
 }
 

--- a/styles/shared.css
+++ b/styles/shared.css
@@ -475,7 +475,7 @@
     display: flex;
     justify-content: center;
     gap: var(--spacing-4);
-    margin-top: var(--spacing-4);
+    margin-top: 16px;
 }
 
 /* ===== レスポンシブ ===== */


### PR DESCRIPTION
## Summary

This PR updates the margin values for share button containers as requested in issue #224:

- Changed `.share-button-container` margin-top to `12px` in index page
- Changed `.shared-actions` margin-top to `16px` in shared page

Closes #224

🤖 Generated with [Claude Code](https://claude.ai/code)