### PR TITLE
feat: update shared screen to display full-size photos with transparent menu overlay

### DIFF
--- a/js/shared-grid.js
+++ b/js/shared-grid.js
@@ -99,11 +99,6 @@
         photoArea.className = 'photo-display-area';
         photoArea.dataset.index = index;
         
-        // テーマテキスト
-        const themeText = document.createElement('div');
-        themeText.className = 'grid-theme-text';
-        themeText.textContent = section.title || `テーマ ${index + 1}`;
-        
         // プラスアイコン
         const addPhotoIcon = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
         addPhotoIcon.setAttribute('class', 'add-photo-icon');
@@ -115,7 +110,6 @@
         
         photoArea.appendChild(addPhotoIcon);
         
-        sectionContainer.appendChild(themeText);
         sectionContainer.appendChild(photoArea);
         gridItem.appendChild(sectionContainer);
         
@@ -205,9 +199,9 @@
         photoArea.classList.add('has-image');
         gridItem.classList.add('has-image');
         
-        // メニューボタンを追加
+        // メニューボタンを追加（透明な背景のオーバーレイ）
         const menuButton = document.createElement('button');
-        menuButton.className = 'grid-menu-button';
+        menuButton.className = 'grid-menu-button grid-menu-overlay';
         menuButton.innerHTML = `
             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                 <circle cx="12" cy="5" r="1"/>
@@ -220,7 +214,7 @@
             showPhotoMenu(index);
         });
         
-        photoArea.appendChild(menuButton);
+        gridItem.appendChild(menuButton);
     }
     
     // 写真メニューを表示

--- a/styles/shared.css
+++ b/styles/shared.css
@@ -72,9 +72,6 @@
 .grid-section-container {
     width: 100%;
     height: 100%;
-    display: flex;
-    flex-direction: column;
-    gap: var(--spacing-2);
     position: relative;
     overflow: hidden;
 }
@@ -87,9 +84,11 @@
 
 /* ===== 写真表示エリア ===== */
 .photo-display-area {
-    position: relative;
-    flex: 1;
+    position: absolute;
+    top: 0;
+    left: 0;
     width: 100%;
+    height: 100%;
     background: rgba(0, 0, 0, 0.05);
     border: 2px dashed rgba(0, 0, 0, 0.2);
     border-radius: var(--radius-lg);
@@ -99,7 +98,6 @@
     cursor: pointer;
     transition: all var(--transition-base);
     overflow: hidden;
-    aspect-ratio: 1;
 }
 
 .photo-display-area.has-image {
@@ -282,11 +280,7 @@
 
 /* ===== グリッドテーマテキスト ===== */
 .grid-theme-text {
-    font-size: var(--text-base);
-    font-weight: var(--font-medium);
-    color: var(--text-primary);
-    text-align: center;
-    margin-bottom: var(--spacing-4);
+    display: none; /* テキストを非表示に */
 }
 
 /* ===== グリッドボタン ===== */
@@ -323,9 +317,20 @@
     justify-content: center;
 }
 
+/* 透明な背景のオーバーレイスタイル */
+.grid-menu-button.grid-menu-overlay {
+    background: rgba(255, 255, 255, 0.2);
+    backdrop-filter: blur(4px);
+    -webkit-backdrop-filter: blur(4px);
+}
+
 .grid-menu-button:hover {
     background: rgba(0, 0, 0, 0.8);
     transform: scale(1.1);
+}
+
+.grid-menu-button.grid-menu-overlay:hover {
+    background: rgba(255, 255, 255, 0.3);
 }
 
 /* ===== アップロードされた画像 ===== */


### PR DESCRIPTION
Fixes #228

- Remove grid-theme-text from shared screen display
- Expand photos to fill entire grid-theme-item
- Replace solid menu button with transparent overlay with backdrop blur
- Position menu button as overlay on grid item instead of photo area

Generated with [Claude Code](https://claude.ai/code)