### PR TITLE
fix: adjust spacing between shared elements

### DIFF
--- a/styles/shared.css
+++ b/styles/shared.css
@@ -10,13 +10,13 @@
 
 .shared-title {
     font-size: var(--text-3xl);
-    margin-bottom: var(--spacing-4);
+    margin-bottom: 18px;
 }
 
 .shared-subtitle {
     font-size: var(--text-lg);
     color: var(--text-secondary);
-    margin-bottom: 0;
+    margin-bottom: var(--spacing-2);
 }
 
 /* ===== 共有ページの背景色セレクター ===== */


### PR DESCRIPTION
## Summary
- Adjusted spacing between shared-title and shared-subtitle to 18px
- Added 8px margin below shared-subtitle for proper spacing with theme-grid

## Test plan
- Check shared.html page to verify spacing looks correct
- Ensure responsive behavior is maintained

Closes #230

🤖 Generated with [Claude Code](https://claude.ai/code)