### PR TITLE
style: add 12px margin above theme-suggestions-container

### DIFF
--- a/styles/app.css
+++ b/styles/app.css
@@ -942,7 +942,7 @@ body {
 
 /* テーマサジェスチョンチップス */
 .theme-suggestions-container {
-    margin-top: 0;
+    margin-top: 12px;
     margin-bottom: 0;
     overflow: hidden;
     position: relative;


### PR DESCRIPTION
## Summary
• Added margin-top: 12px to theme-suggestions-container in styles/app.css

## Test plan
[] Visual inspection of the theme suggestions spacing
[] Check responsiveness on different screen sizes

Closes #231

🤖 Generated with [Claude Code](https://claude.ai/code)