### PR TITLE
feat: add SNS sharing functionality to shared page

### DIFF
--- a/js/shared-grid.js
+++ b/js/shared-grid.js
@@ -21,6 +21,11 @@
         mainShareBtn: document.getElementById('main-share-btn'),
         downloadBtn: document.getElementById('download-grid-btn'),
         shareInstagramBtn: document.getElementById('share-instagram-btn'),
+        copyUrlBtn: document.getElementById('copy-url-btn'),
+        shareTwitterBtn: document.getElementById('share-twitter-btn'),
+        shareFacebookBtn: document.getElementById('share-facebook-btn'),
+        shareLineBtn: document.getElementById('share-line-btn'),
+        shareUrlInput: document.getElementById('share-url-input'),
         gridBgColorInput: document.getElementById('grid-bg-color'),
         shareModal: document.getElementById('share-modal'),
         shareModalClose: null
@@ -345,6 +350,11 @@
         if (elements.shareModal) {
             elements.shareModal.classList.add('active');
         }
+        
+        // 現在のURLを共有URLとして設定
+        if (elements.shareUrlInput) {
+            elements.shareUrlInput.value = window.location.href;
+        }
     }
     
     // 共有モーダルを閉じる
@@ -352,6 +362,42 @@
         if (elements.shareModal) {
             elements.shareModal.classList.remove('active');
         }
+    }
+    
+    // URLをコピー
+    async function copyShareUrl() {
+        const shareUrl = window.location.href;
+        
+        try {
+            await navigator.clipboard.writeText(shareUrl);
+            showToast('URLをコピーしました', 'success');
+        } catch (err) {
+            console.error('コピーエラー:', err);
+            showToast('URLのコピーに失敗しました', 'error');
+        }
+    }
+    
+    // Twitterで共有
+    function shareOnTwitter() {
+        const shareUrl = window.location.href;
+        const text = encodeURIComponent('GridMe!!でフォトグリッドを作成しました！');
+        const twitterUrl = `https://twitter.com/intent/tweet?text=${text}&url=${encodeURIComponent(shareUrl)}`;
+        window.open(twitterUrl, '_blank', 'width=600,height=400');
+    }
+    
+    // Facebookで共有
+    function shareOnFacebook() {
+        const shareUrl = window.location.href;
+        const facebookUrl = `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(shareUrl)}`;
+        window.open(facebookUrl, '_blank', 'width=600,height=400');
+    }
+    
+    // LINEで共有
+    function shareOnLine() {
+        const shareUrl = window.location.href;
+        const text = encodeURIComponent('GridMe!!でフォトグリッドを作成しました！');
+        const lineUrl = `https://social-plugins.line.me/lineit/share?url=${encodeURIComponent(shareUrl)}&text=${text}`;
+        window.open(lineUrl, '_blank', 'width=600,height=400');
     }
     
     // Instagram Stories共有機能
@@ -485,6 +531,31 @@
             elements.shareInstagramBtn.addEventListener('click', () => {
                 shareInstagramStories();
                 closeShareModal();
+            });
+        }
+        
+        // 新しいSNS共有ボタンのイベントリスナー
+        if (elements.copyUrlBtn) {
+            elements.copyUrlBtn.addEventListener('click', () => {
+                copyShareUrl();
+            });
+        }
+        
+        if (elements.shareTwitterBtn) {
+            elements.shareTwitterBtn.addEventListener('click', () => {
+                shareOnTwitter();
+            });
+        }
+        
+        if (elements.shareFacebookBtn) {
+            elements.shareFacebookBtn.addEventListener('click', () => {
+                shareOnFacebook();
+            });
+        }
+        
+        if (elements.shareLineBtn) {
+            elements.shareLineBtn.addEventListener('click', () => {
+                shareOnLine();
             });
         }
         

--- a/shared.html
+++ b/shared.html
@@ -112,6 +112,31 @@
             </div>
             <div class="app-modal-body">
                 <div class="share-options">
+                    <button class="share-option-btn" id="copy-url-btn">
+                        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <rect x="9" y="9" width="13" height="13" rx="2" ry="2"/>
+                            <path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/>
+                        </svg>
+                        <span>URLをコピー</span>
+                    </button>
+                    <button class="share-option-btn" id="share-twitter-btn">
+                        <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+                            <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
+                        </svg>
+                        <span>X (Twitter)</span>
+                    </button>
+                    <button class="share-option-btn" id="share-facebook-btn">
+                        <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+                            <path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/>
+                        </svg>
+                        <span>Facebook</span>
+                    </button>
+                    <button class="share-option-btn" id="share-line-btn">
+                        <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+                            <path d="M19.365 9.863c.349 0 .63.285.63.631 0 .345-.281.63-.63.63H17.61v1.125h1.755c.349 0 .63.283.63.63 0 .344-.281.629-.63.629h-2.386c-.345 0-.627-.285-.627-.629V8.108c0-.345.282-.63.63-.63h2.386c.346 0 .627.285.627.63 0 .349-.281.63-.63.63H17.61v1.125h1.755zm-3.855 3.016c0 .27-.174.51-.432.596-.064.021-.133.031-.199.031-.211 0-.391-.09-.51-.25l-2.443-3.317v2.94c0 .344-.279.629-.631.629-.346 0-.626-.285-.626-.629V8.108c0-.27.173-.51.43-.595.06-.023.136-.033.194-.033.195 0 .375.104.495.254l2.462 3.33V8.108c0-.345.282-.63.63-.63.345 0 .63.285.63.63v4.771zm-5.741 0c0 .344-.282.629-.631.629-.345 0-.627-.285-.627-.629V8.108c0-.345.282-.63.627-.63.349 0 .631.285.631.63v4.771zm-2.466.629H4.917c-.345 0-.63-.285-.63-.629V8.108c0-.345.285-.63.63-.63.349 0 .63.285.63.63v4.141h1.756c.348 0 .629.283.629.63 0 .344-.282.629-.629.629M24 10.314C24 4.943 18.615.572 12 .572S0 4.943 0 10.314c0 4.811 4.27 8.842 10.035 9.608.391.082.923.258 1.058.59.12.301.079.766.038 1.08l-.164 1.02c-.045.301-.24 1.186 1.049.645 1.291-.539 6.916-4.078 9.436-6.975C23.176 14.393 24 12.458 24 10.314"/>
+                        </svg>
+                        <span>LINE</span>
+                    </button>
                     <button class="share-option-btn" id="download-grid-btn">
                         <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                             <path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/>
@@ -126,6 +151,9 @@
                         </svg>
                         <span>Instagram Stories</span>
                     </button>
+                </div>
+                <div class="share-url-preview">
+                    <input type="text" id="share-url-input" class="input" readonly>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
• Added SNS sharing buttons (URL copy, Twitter, Facebook, LINE) to the shared page's share modal
• Implemented JavaScript functions for each sharing option
• Added share URL input field to display the current page URL

This brings feature parity with the index page's sharing capabilities.

Fixes #229

Generated with [Claude Code](https://claude.ai/code)