### PR TITLE
feat: make grid-menu-overlay background more transparent

### DIFF
--- a/styles/shared.css
+++ b/styles/shared.css
@@ -319,9 +319,10 @@
 
 /* 透明な背景のオーバーレイスタイル */
 .grid-menu-button.grid-menu-overlay {
-    background: rgba(255, 255, 255, 0.2);
-    backdrop-filter: blur(4px);
-    -webkit-backdrop-filter: blur(4px);
+    background: rgba(255, 255, 255, 0.1);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+    border: 1px solid rgba(255, 255, 255, 0.2);
 }
 
 .grid-menu-button:hover {
@@ -330,7 +331,8 @@
 }
 
 .grid-menu-button.grid-menu-overlay:hover {
-    background: rgba(255, 255, 255, 0.3);
+    background: rgba(255, 255, 255, 0.15);
+    border-color: rgba(255, 255, 255, 0.3);
 }
 
 /* ===== アップロードされた画像 ===== */


### PR DESCRIPTION
This PR makes the grid-menu-overlay background more transparent so it can be better superimposed on photos.

## Changes
- Reduced background opacity from 0.2 to 0.1 for better photo visibility
- Increased blur effect from 4px to 8px for enhanced glass morphism
- Added subtle white border for better button visibility
- Updated hover state with matching transparency

Closes #235

Generated with [Claude Code](https://claude.ai/code)