### PR TITLE
fix: ensure grid-section-container is always square

### DIFF
--- a/styles/app.css
+++ b/styles/app.css
@@ -829,6 +829,7 @@ body {
     display: flex;
     align-items: center;
     justify-content: center;
+    aspect-ratio: 1;
 }
 
 /* セクションタイトル入力 */

--- a/styles/shared.css
+++ b/styles/shared.css
@@ -74,6 +74,7 @@
     height: 100%;
     position: relative;
     overflow: hidden;
+    aspect-ratio: 1;
 }
 
 /* 共有セクションタイトル - 削除: グリッドテーマテキストで統一 */


### PR DESCRIPTION
## Summary

Implemented CSS changes to ensure grid-section-container maintains a square aspect ratio.

## Changes
- Added `aspect-ratio: 1` to grid-section-container in app.css
- Added `aspect-ratio: 1` to grid-section-container in shared.css

This ensures all grid items maintain a 1:1 aspect ratio across the application.

Closes #237

Generated with [Claude Code](https://claude.ai/code)