### PR TITLE
feat: add theme text display on shared page when no photos are set

### DIFF
--- a/js/shared-grid.js
+++ b/js/shared-grid.js
@@ -95,6 +95,14 @@
         gridItem.className = 'grid-theme-item';
         gridItem.dataset.index = index;
         
+        // テーマテキストを追加
+        if (section.title) {
+            const themeText = document.createElement('div');
+            themeText.className = 'theme-text';
+            themeText.textContent = section.title;
+            gridItem.appendChild(themeText);
+        }
+        
         // セクションコンテナ
         const sectionContainer = document.createElement('div');
         sectionContainer.className = 'grid-section-container';
@@ -204,6 +212,12 @@
         photoArea.classList.add('has-image');
         gridItem.classList.add('has-image');
         
+        // 画像がある場合はテーマテキストを非表示
+        const themeText = gridItem.querySelector('.theme-text');
+        if (themeText) {
+            themeText.style.display = 'none';
+        }
+        
         // メニューボタンを追加（透明な背景のオーバーレイ）
         const menuButton = document.createElement('button');
         menuButton.className = 'grid-menu-button grid-menu-overlay';
@@ -299,6 +313,18 @@
         // クラスを削除
         photoArea.classList.remove('has-image');
         gridItem.classList.remove('has-image');
+        
+        // テーマテキストを再表示
+        const themeText = gridItem.querySelector('.theme-text');
+        if (themeText) {
+            themeText.style.display = '';
+        }
+        
+        // メニューボタンを削除
+        const menuButton = gridItem.querySelector('.grid-menu-button');
+        if (menuButton) {
+            menuButton.remove();
+        }
         
         // コンテンツをリセット
         photoArea.innerHTML = '';

--- a/styles/shared.css
+++ b/styles/shared.css
@@ -277,11 +277,41 @@
     .grid-theme-text {
         color: var(--text-primary);
     }
+    
+    /* テーマテキスト */
+    .theme-text {
+        background: rgba(0, 0, 0, 0.8);
+        color: var(--text-secondary);
+    }
 }
 
 /* ===== グリッドテーマテキスト ===== */
 .grid-theme-text {
     display: none; /* テキストを非表示に */
+}
+
+/* ===== テーマテキスト ===== */
+.theme-text {
+    position: absolute;
+    top: 8px;
+    left: 8px;
+    right: 8px;
+    font-size: var(--text-sm);
+    font-weight: var(--font-medium);
+    color: var(--text-secondary);
+    background: rgba(255, 255, 255, 0.9);
+    padding: 4px 8px;
+    border-radius: var(--radius-sm);
+    z-index: 1;
+    text-align: center;
+    backdrop-filter: blur(4px);
+    -webkit-backdrop-filter: blur(4px);
+}
+
+/* ダークモード時のテーマテキスト */
+.dark-theme .theme-text {
+    background: rgba(0, 0, 0, 0.8);
+    color: var(--text-secondary);
 }
 
 /* ===== グリッドボタン ===== */


### PR DESCRIPTION
## Summary

This PR adds theme text display to the shared page grid sections when no photos are uploaded, making it clear what theme each section represents.

## Changes

- Display theme text above grid section container when no photo is uploaded
- Hide theme text when photo is added
- Show theme text again when photo is removed
- Add proper styling with backdrop filter and dark mode support
- Position theme text at the top of each grid section

Closes #243

🤖 Generated with [Claude Code](https://claude.ai/code)