### PR TITLE
feat: update grid layout to vertical arrangement

### DIFF
--- a/js/photo-grid-refactored.js
+++ b/js/photo-grid-refactored.js
@@ -64,10 +64,6 @@ import { toast, modal, storage, share, GridRenderer, theme } from './utils/index
         defaultSize: 3,
         itemClass: 'grid-theme-item',
         renderItem: (item, section, index) => {
-            // セクションコンテナ
-            const sectionContainer = document.createElement('div');
-            sectionContainer.className = 'grid-section-container';
-            
             // タイトル入力
             const titleInput = document.createElement('textarea');
             titleInput.className = 'section-title-input';
@@ -91,7 +87,26 @@ import { toast, modal, storage, share, GridRenderer, theme } from './utils/index
                 }, 200);
             });
             
-            sectionContainer.appendChild(titleInput);
+            // セクションコンテナ（プラスアイコン用）
+            const sectionContainer = document.createElement('div');
+            sectionContainer.className = 'grid-section-container';
+            
+            // プラスアイコン
+            const addIcon = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+            addIcon.setAttribute('class', 'add-photo-icon');
+            addIcon.setAttribute('viewBox', '0 0 24 24');
+            addIcon.setAttribute('fill', 'none');
+            addIcon.setAttribute('stroke', 'currentColor');
+            addIcon.setAttribute('stroke-width', '2');
+            addIcon.style.width = '48px';
+            addIcon.style.height = '48px';
+            addIcon.style.color = 'var(--text-tertiary)';
+            addIcon.innerHTML = '<line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/>';
+            
+            sectionContainer.appendChild(addIcon);
+            
+            // 要素の組み立て - テキストを上に、コンテナを下に
+            item.appendChild(titleInput);
             item.appendChild(sectionContainer);
         }
     });

--- a/js/shared-grid-refactored.js
+++ b/js/shared-grid-refactored.js
@@ -85,45 +85,53 @@ import { toast, modal, share, GridRenderer, StorageManager, theme } from './util
     const gridRenderer = new GridRenderer('photo-theme-grid', {
         itemClass: 'grid-theme-item',
         renderItem: (gridItem, section, index) => {
+            // テーマテキストを上に表示
+            const themeText = document.createElement('div');
+            themeText.className = 'theme-text';
+            themeText.textContent = section.title || `テーマ ${index + 1}`;
+            gridItem.appendChild(themeText);
+            
             // セクションコンテナ
             const sectionContainer = document.createElement('div');
             sectionContainer.className = 'grid-section-container';
             
+            // 写真表示エリア
+            const photoArea = document.createElement('div');
+            photoArea.className = 'photo-display-area';
+            photoArea.dataset.index = index;
+            
             // 既に画像がアップロードされている場合
             if (state.uploadedImages[index]) {
                 // has-imageクラスを追加
+                photoArea.classList.add('has-image');
                 gridItem.classList.add('has-image');
                 
-                // 画像を表示（正方形にクロップ）
+                // 画像を表示
                 const img = document.createElement('img');
                 img.className = 'uploaded-image';
                 img.src = state.uploadedImages[index];
                 img.alt = `アップロードされた画像 ${index + 1}`;
-                sectionContainer.appendChild(img);
-                
-                // メニューボタンとプラスボタンは表示しない
+                photoArea.appendChild(img);
             } else {
-                // テーマテキストを表示
-                const themeText = document.createElement('div');
-                themeText.className = 'grid-theme-text';
-                themeText.textContent = section.title || `テーマ ${index + 1}`;
-                sectionContainer.appendChild(themeText);
-                
                 // プラスアイコン
-                const addButton = document.createElement('button');
-                addButton.className = 'grid-add-button';
-                addButton.innerHTML = `
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                        <line x1="12" y1="5" x2="12" y2="19"/>
-                        <line x1="5" y1="12" x2="19" y2="12"/>
-                    </svg>
-                `;
-                addButton.addEventListener('click', (e) => {
-                    e.stopPropagation();
-                    openUploadModal(index);
-                });
-                sectionContainer.appendChild(addButton);
+                const addPhotoIcon = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+                addPhotoIcon.setAttribute('class', 'add-photo-icon');
+                addPhotoIcon.setAttribute('viewBox', '0 0 24 24');
+                addPhotoIcon.setAttribute('fill', 'none');
+                addPhotoIcon.setAttribute('stroke', 'currentColor');
+                addPhotoIcon.setAttribute('stroke-width', '2');
+                addPhotoIcon.innerHTML = '<line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/>';
+                
+                photoArea.appendChild(addPhotoIcon);
             }
+            
+            // クリックイベントの設定
+            photoArea.addEventListener('click', (e) => {
+                e.stopPropagation();
+                openUploadModal(index);
+            });
+            
+            sectionContainer.appendChild(photoArea);
             
             // テーマクラスを適用（存在する場合）
             if (section.theme) {
@@ -131,11 +139,6 @@ import { toast, modal, share, GridRenderer, StorageManager, theme } from './util
             }
             
             gridItem.appendChild(sectionContainer);
-            
-            // クリックイベントの設定
-            if (!state.uploadedImages[index]) {
-                gridItem.addEventListener('click', () => openUploadModal(index));
-            }
         }
     });
     

--- a/js/shared-grid.js
+++ b/js/shared-grid.js
@@ -175,10 +175,8 @@
     
     // 写真エリアのクリックハンドラー
     function handlePhotoAreaClick(e, index) {
-        // 画像がアップロードされていない場合のみモーダルを開く
-        if (!state.uploadedImages[index]) {
-            openUploadModal(index);
-        }
+        // Always open upload modal when clicking on photo area
+        openUploadModal(index);
     }
     
     // アップロードモーダルを開く
@@ -240,98 +238,11 @@
         photoArea.classList.add('has-image');
         gridItem.classList.add('has-image');
         
-        // 画像がある場合はテーマテキストを非表示
-        const themeText = gridItem.querySelector('.theme-text');
-        if (themeText) {
-            themeText.style.display = 'none';
-        }
-        
-        // メニューボタンを追加（透明な背景のオーバーレイ）
-        const menuButton = document.createElement('button');
-        menuButton.className = 'grid-menu-button grid-menu-overlay';
-        menuButton.innerHTML = `
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                <circle cx="12" cy="5" r="1"/>
-                <circle cx="12" cy="12" r="1"/>
-                <circle cx="12" cy="19" r="1"/>
-            </svg>
-        `;
-        menuButton.addEventListener('click', (e) => {
-            e.stopPropagation();
-            showPhotoMenu(index);
-        });
-        
-        gridItem.appendChild(menuButton);
+        // Do not hide theme text when image is uploaded - keep it above the image
+        // grid-menu-button functionality removed as requested
     }
     
-    // 写真メニューを表示
-    function showPhotoMenu(index) {
-        // 既存のメニューを削除
-        const existingMenu = document.getElementById('photo-menu-modal');
-        if (existingMenu) {
-            existingMenu.remove();
-        }
-        
-        // メニューモーダルを作成
-        const menuModal = document.createElement('div');
-        menuModal.id = 'photo-menu-modal';
-        menuModal.className = 'app-modal active';
-        menuModal.innerHTML = `
-            <div class="app-modal-content card-glass" style="max-width: 300px;">
-                <div class="app-modal-header">
-                    <h3>写真の編集</h3>
-                    <button class="btn-icon app-modal-close" aria-label="閉じる">
-                        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                            <line x1="18" y1="6" x2="6" y2="18"/>
-                            <line x1="6" y1="6" x2="18" y2="18"/>
-                        </svg>
-                    </button>
-                </div>
-                <div class="app-modal-body">
-                    <div class="edit-menu-options">
-                        <button class="edit-menu-option" data-action="change">
-                            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                                <path d="M23 4v6h-6M1 20v-6h6M3.51 9a9 9 0 0114.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0020.49 15"/>
-                            </svg>
-                            <span>写真を変更</span>
-                        </button>
-                        <button class="edit-menu-option edit-menu-delete" data-action="delete">
-                            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                                <polyline points="3 6 5 6 21 6"/>
-                                <path d="M19 6v14a2 2 0 01-2 2H7a2 2 0 01-2-2V6m3 0V4a2 2 0 012-2h4a2 2 0 012 2v2"/>
-                            </svg>
-                            <span>写真を削除</span>
-                        </button>
-                    </div>
-                </div>
-            </div>
-        `;
-        
-        document.body.appendChild(menuModal);
-        
-        // イベントリスナーを設定
-        const closeBtn = menuModal.querySelector('.app-modal-close');
-        closeBtn.addEventListener('click', () => menuModal.remove());
-        
-        menuModal.addEventListener('click', (e) => {
-            if (e.target === menuModal) {
-                menuModal.remove();
-            }
-        });
-        
-        // メニューアクション
-        menuModal.querySelector('[data-action="change"]').addEventListener('click', () => {
-            menuModal.remove();
-            openUploadModal(index);
-        });
-        
-        menuModal.querySelector('[data-action="delete"]').addEventListener('click', () => {
-            delete state.uploadedImages[index];
-            resetPhotoDisplay(index);
-            menuModal.remove();
-            showToast('写真を削除しました', 'success');
-        });
-    }
+    // Photo menu functionality removed as grid-menu-button is deleted
     
     // 写真表示をリセット
     function resetPhotoDisplay(index) {
@@ -342,17 +253,7 @@
         photoArea.classList.remove('has-image');
         gridItem.classList.remove('has-image');
         
-        // テーマテキストを再表示
-        const themeText = gridItem.querySelector('.theme-text');
-        if (themeText) {
-            themeText.style.display = '';
-        }
-        
-        // メニューボタンを削除
-        const menuButton = gridItem.querySelector('.grid-menu-button');
-        if (menuButton) {
-            menuButton.remove();
-        }
+        // Theme text remains visible as it's now positioned above the image area
         
         // コンテンツをリセット
         photoArea.innerHTML = '';

--- a/js/theme-grid.js
+++ b/js/theme-grid.js
@@ -113,10 +113,6 @@
         gridItem.className = 'grid-theme-item';
         gridItem.dataset.index = index;
         
-        // セクションコンテナ
-        const sectionContainer = document.createElement('div');
-        sectionContainer.className = 'grid-section-container';
-        
         // タイトル入力（テーマ入力として使用）
         const titleInput = document.createElement('textarea');
         titleInput.className = 'section-title-input';
@@ -141,8 +137,26 @@
             }, 200);
         });
         
-        // 要素の組み立て
-        sectionContainer.appendChild(titleInput);
+        // セクションコンテナ（プラスアイコン用）
+        const sectionContainer = document.createElement('div');
+        sectionContainer.className = 'grid-section-container';
+        
+        // プラスアイコン
+        const addIcon = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+        addIcon.setAttribute('class', 'add-photo-icon');
+        addIcon.setAttribute('viewBox', '0 0 24 24');
+        addIcon.setAttribute('fill', 'none');
+        addIcon.setAttribute('stroke', 'currentColor');
+        addIcon.setAttribute('stroke-width', '2');
+        addIcon.style.width = '48px';
+        addIcon.style.height = '48px';
+        addIcon.style.color = 'var(--text-tertiary)';
+        addIcon.innerHTML = '<line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/>';
+        
+        sectionContainer.appendChild(addIcon);
+        
+        // 要素の組み立て - テキストを上に、コンテナを下に
+        gridItem.appendChild(titleInput);
         gridItem.appendChild(sectionContainer);
         
         return gridItem;

--- a/styles/app.css
+++ b/styles/app.css
@@ -810,8 +810,9 @@ body {
     overflow: hidden;
     transition: all var(--transition-base);
     display: flex;
+    flex-direction: column;
     align-items: center;
-    justify-content: center;
+    justify-content: flex-start;
     padding: var(--spacing-3);
     min-height: 100px;
     aspect-ratio: 1;
@@ -825,11 +826,11 @@ body {
 /* グリッドセクションコンテナ */
 .grid-section-container {
     width: 100%;
-    height: 100%;
+    flex: 1;
     display: flex;
     align-items: center;
     justify-content: center;
-    aspect-ratio: 1;
+    background: transparent;
 }
 
 /* セクションタイトル入力 */
@@ -842,11 +843,13 @@ body {
     font-weight: var(--font-normal);
     font-family: inherit;
     transition: all var(--transition-base);
-    background: white; /* Pure white background */
+    background: transparent;
     color: var(--text-secondary);
     resize: none;
     overflow: hidden;
     line-height: 1.4;
+    text-align: center;
+    margin-bottom: var(--spacing-2);
     min-height: 2.4em;
     text-align: center;
     vertical-align: middle;

--- a/styles/shared.css
+++ b/styles/shared.css
@@ -56,8 +56,9 @@
     overflow: hidden;
     transition: all var(--transition-base);
     display: flex;
+    flex-direction: column;
     align-items: center;
-    justify-content: center;
+    justify-content: flex-start;
     padding: var(--spacing-3);
     min-height: 100px;
     aspect-ratio: 1;
@@ -71,10 +72,13 @@
 /* グリッドセクションコンテナ */
 .grid-section-container {
     width: 100%;
-    height: 100%;
+    flex: 1;
     position: relative;
     overflow: hidden;
-    aspect-ratio: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: transparent;
 }
 
 /* 共有セクションタイトル - 削除: グリッドテーマテキストで統一 */
@@ -90,8 +94,8 @@
     left: 0;
     width: 100%;
     height: 100%;
-    background: rgba(0, 0, 0, 0.05);
-    border: 2px dashed rgba(0, 0, 0, 0.2);
+    background: transparent;
+    border: none;
     border-radius: var(--radius-lg);
     display: flex;
     align-items: center;
@@ -107,8 +111,7 @@
 }
 
 .photo-display-area:hover {
-    background: rgba(0, 0, 0, 0.08);
-    border-color: rgba(0, 0, 0, 0.3);
+    background: transparent;
 }
 
 /* カードフリップ関連 - 削除: フリップ機能を使用しない */
@@ -193,6 +196,7 @@
 
 .dark-theme .grid-theme-item.theme-modern {
     background-color: #0f0f0f;
+}
 
 .dark-theme .photo-theme-item.theme-default {
     background-color: #2a2a2a;
@@ -229,13 +233,11 @@
 }
 
 .dark-theme .photo-display-area {
-    background: rgba(255, 255, 255, 0.05);
-    border-color: rgba(255, 255, 255, 0.2);
+    background: transparent;
 }
 
 .dark-theme .photo-display-area:hover {
-    background: rgba(255, 255, 255, 0.08);
-    border-color: rgba(255, 255, 255, 0.3);
+    background: transparent;
 }
 
 .dark-theme .flip-card-back {
@@ -280,7 +282,6 @@
     
     /* テーマテキスト */
     .theme-text {
-        background: rgba(0, 0, 0, 0.8);
         color: var(--text-secondary);
     }
 }
@@ -292,25 +293,18 @@
 
 /* ===== テーマテキスト ===== */
 .theme-text {
-    position: absolute;
-    top: 8px;
-    left: 8px;
-    right: 8px;
+    position: relative;
+    width: 100%;
     font-size: var(--text-sm);
     font-weight: var(--font-medium);
     color: var(--text-secondary);
-    background: rgba(255, 255, 255, 0.9);
-    padding: 4px 8px;
-    border-radius: var(--radius-sm);
-    z-index: 1;
+    padding: 0;
+    margin-bottom: var(--spacing-2);
     text-align: center;
-    backdrop-filter: blur(4px);
-    -webkit-backdrop-filter: blur(4px);
 }
 
 /* ダークモード時のテーマテキスト */
 .dark-theme .theme-text {
-    background: rgba(0, 0, 0, 0.8);
     color: var(--text-secondary);
 }
 
@@ -329,42 +323,7 @@
     transform: scale(1.1);
 }
 
-.grid-menu-button {
-    position: absolute;
-    top: 8px;
-    right: 8px;
-    background: rgba(0, 0, 0, 0.6);
-    border: none;
-    border-radius: var(--radius-full);
-    padding: 6px;
-    cursor: pointer;
-    color: white;
-    transition: all var(--transition-base);
-    z-index: 10;
-    width: 32px;
-    height: 32px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-}
-
-/* 透明な背景のオーバーレイスタイル */
-.grid-menu-button.grid-menu-overlay {
-    background: rgba(255, 255, 255, 0.1);
-    backdrop-filter: blur(8px);
-    -webkit-backdrop-filter: blur(8px);
-    border: 1px solid rgba(255, 255, 255, 0.2);
-}
-
-.grid-menu-button:hover {
-    background: rgba(0, 0, 0, 0.8);
-    transform: scale(1.1);
-}
-
-.grid-menu-button.grid-menu-overlay:hover {
-    background: rgba(255, 255, 255, 0.15);
-    border-color: rgba(255, 255, 255, 0.3);
-}
+/* grid-menu-button and grid-menu-overlay deleted as requested */
 
 /* ===== アップロードされた画像 ===== */
 .uploaded-image {


### PR DESCRIPTION
## Summary

This PR updates the grid layout to display theme text above the image container and removes the grid menu functionality.

## Changes
- Arrange theme-text and grid-section-container vertically (text above image)
- Remove frame/border from grid-section-container, display only plus icon
- Make grid-section-container background transparent
- Delete grid-menu-button and grid-menu-overlay components and functionality
- Update all grid-related JavaScript files to reflect new layout structure

Closes #247

Generated with [Claude Code](https://claude.ai/code)