### PR TITLE
fix: 画像グリッドUIの改善

### DIFF
--- a/js/shared-grid.js
+++ b/js/shared-grid.js
@@ -238,8 +238,11 @@
         photoArea.classList.add('has-image');
         gridItem.classList.add('has-image');
         
-        // Do not hide theme text when image is uploaded - keep it above the image
-        // grid-menu-button functionality removed as requested
+        // Hide theme text when image is uploaded
+        const themeText = gridItem.querySelector('.theme-text');
+        if (themeText) {
+            themeText.style.display = 'none';
+        }
     }
     
     // Photo menu functionality removed as grid-menu-button is deleted
@@ -253,7 +256,11 @@
         photoArea.classList.remove('has-image');
         gridItem.classList.remove('has-image');
         
-        // Theme text remains visible as it's now positioned above the image area
+        // Show theme text again when image is removed
+        const themeText = gridItem.querySelector('.theme-text');
+        if (themeText) {
+            themeText.style.display = 'block';
+        }
         
         // コンテンツをリセット
         photoArea.innerHTML = '';

--- a/js/theme-grid.js
+++ b/js/theme-grid.js
@@ -137,27 +137,8 @@
             }, 200);
         });
         
-        // セクションコンテナ（プラスアイコン用）
-        const sectionContainer = document.createElement('div');
-        sectionContainer.className = 'grid-section-container';
-        
-        // プラスアイコン
-        const addIcon = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
-        addIcon.setAttribute('class', 'add-photo-icon');
-        addIcon.setAttribute('viewBox', '0 0 24 24');
-        addIcon.setAttribute('fill', 'none');
-        addIcon.setAttribute('stroke', 'currentColor');
-        addIcon.setAttribute('stroke-width', '2');
-        addIcon.style.width = '48px';
-        addIcon.style.height = '48px';
-        addIcon.style.color = 'var(--text-tertiary)';
-        addIcon.innerHTML = '<line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/>';
-        
-        sectionContainer.appendChild(addIcon);
-        
-        // 要素の組み立て - テキストを上に、コンテナを下に
+        // 要素の組み立て - テキストのみ追加
         gridItem.appendChild(titleInput);
-        gridItem.appendChild(sectionContainer);
         
         return gridItem;
     }

--- a/styles/shared.css
+++ b/styles/shared.css
@@ -118,8 +118,8 @@
 
 /* プラスアイコン */
 .add-photo-icon {
-    width: 48px;
-    height: 48px;
+    width: 32px;
+    height: 32px;
     color: var(--text-tertiary);
     transition: all var(--transition-base);
 }
@@ -144,6 +144,11 @@
 
 .grid-theme-item.has-image .grid-section-container {
     padding: 0;
+}
+
+/* 画像がある場合はテーマテキストを非表示に */
+.grid-theme-item.has-image .theme-text {
+    display: none !important;
 }
 
 /* テーマテキスト - 削除: グリッドテーマテキストで統一 */
@@ -327,6 +332,9 @@
 
 /* ===== アップロードされた画像 ===== */
 .uploaded-image {
+    position: absolute;
+    top: 0;
+    left: 0;
     width: 100%;
     height: 100%;
     object-fit: cover;


### PR DESCRIPTION
## Summary
- Indexページのメイングリッドからプラスアイコンを削除
- Sharedページのプラスアイコンを小さく変更
- 画像が追加されたらテーマテキストを非表示に
- 画像が正方形で表示されるように調整

Closes #249

Generated with [Claude Code](https://claude.ai/code)