### PR TITLE
fix: update share button text and unify button design

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,7 +84,7 @@
                             <polyline points="16 6 12 2 8 6"/>
                             <line x1="12" y1="2" x2="12" y2="15"/>
                         </svg>
-                        GridMeを共有
+                        Gridをシェアする
                     </button>
                 </div>
 
@@ -106,7 +106,7 @@
     <div class="app-modal" id="share-modal">
         <div class="app-modal-content card-glass" style="max-width: 400px;">
             <div class="app-modal-header">
-                <h3>GridMeを共有</h3>
+                <h3>Gridをシェアする</h3>
                 <button class="btn-icon app-modal-close" aria-label="閉じる">
                     <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                         <line x1="18" y1="6" x2="6" y2="18"/>

--- a/shared.html
+++ b/shared.html
@@ -51,14 +51,14 @@
                 </div>
                 
                 <!-- アクションボタン -->
-                <div class="shared-actions">
+                <div class="share-button-container">
                     <button class="btn-primary btn-lg" id="main-share-btn">
                         <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="margin-right: 8px;">
                             <path d="M4 12v8a2 2 0 002 2h12a2 2 0 002-2v-8"/>
                             <polyline points="16 6 12 2 8 6"/>
                             <line x1="12" y1="2" x2="12" y2="15"/>
                         </svg>
-                        グリッドを共有
+                        Gridをシェアする
                     </button>
                 </div>
             </section>
@@ -102,7 +102,7 @@
     <div class="app-modal" id="share-modal">
         <div class="app-modal-content card-glass" style="max-width: 400px;">
             <div class="app-modal-header">
-                <h3>グリッドを共有</h3>
+                <h3>Gridをシェアする</h3>
                 <button class="btn-icon app-modal-close" aria-label="閉じる">
                     <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                         <line x1="18" y1="6" x2="6" y2="18"/>


### PR DESCRIPTION
## Summary
- Change share button text to "Gridをシェアする" on all pages
- Unify button design using index page's style

## Test plan
- [ ] Verify all share buttons display "Gridをシェアする"
- [ ] Verify share button design is consistent between index and shared pages
- [ ] Test share functionality still works correctly

Closes #256

🤖 Generated with [Claude Code](https://claude.ai/code)