### PR TITLE
・ 枠余白

### DIFF
--- a/styles/app.css
+++ b/styles/app.css
@@ -798,7 +798,7 @@ body {
     width: calc(100% - 32px);
     margin: 0 auto;
     background: var(--bg-secondary);
-    padding: 6px;
+    padding: 12px;
     border-radius: var(--radius-xl);
     box-shadow: var(--shadow-xl);
 }
@@ -1363,7 +1363,7 @@ body {
     .theme-grid {
         max-width: 780px;
         width: calc(100% - 32px);
-        padding: 6px;
+        padding: 12px;
         gap: 6px;
     }
     
@@ -1380,7 +1380,7 @@ body {
 @media (max-width: 480px) {
     .theme-grid {
         gap: 6px;
-        padding: 6px;
+        padding: 12px;
         width: calc(100% - 32px);
         max-width: 780px;
     }

--- a/styles/shared.css
+++ b/styles/shared.css
@@ -43,7 +43,7 @@
     width: calc(100% - 32px);
     margin: 0 auto var(--spacing-6) auto;
     background: var(--bg-secondary);
-    padding: 6px;
+    padding: 12px;
     border-radius: var(--radius-xl);
     box-shadow: var(--shadow-xl);
 }
@@ -454,7 +454,7 @@
     .theme-grid {
         max-width: 780px;
         width: calc(100% - 32px);
-        padding: 6px;
+        padding: 12px;
         gap: 6px;
     }
     
@@ -472,7 +472,7 @@
 @media (max-width: 480px) {
     .theme-grid {
         gap: 6px;
-        padding: 6px;
+        padding: 12px;
         width: calc(100% - 32px);
         max-width: 780px;
     }


### PR DESCRIPTION
## 📋 内容
index,shared両方のtheme-gridの枠の余白を12pxに広げました。

Closes #261

Generated with [Claude Code](https://claude.ai/code)