### PR TITLE
fix: standardize grid-theme-item borders to 12px

### DIFF
--- a/styles/app.css
+++ b/styles/app.css
@@ -806,6 +806,7 @@ body {
 .grid-theme-item {
     position: relative;
     background: var(--bg-primary);
+    border: 12px solid var(--bg-secondary);
     border-radius: var(--radius-lg);
     overflow: hidden;
     transition: all var(--transition-base);
@@ -1058,17 +1059,14 @@ body {
 /* ダークモード対応 */
 .dark-theme .grid-theme-item.theme-default {
     background-color: #2a2a2a;
-    border: 1px solid rgba(255, 255, 255, 0.1);
 }
 
 .dark-theme .grid-theme-item.theme-warm {
     background-color: #3d2820;
-    border: 1px solid rgba(255, 139, 37, 0.2);
 }
 
 .dark-theme .grid-theme-item.theme-cool {
     background-color: #202838;
-    border: 1px solid rgba(6, 182, 212, 0.2);
 }
 
 .dark-theme .theme-chip {
@@ -1081,17 +1079,14 @@ body {
 
 .dark-theme .grid-theme-item.theme-nature {
     background-color: #1a2f1a;
-    border: 1px solid rgba(16, 185, 129, 0.2);
 }
 
 .dark-theme .grid-theme-item.theme-elegant {
     background-color: #2f1a3d;
-    border: 1px solid rgba(139, 92, 246, 0.2);
 }
 
 .dark-theme .grid-theme-item.theme-modern {
     background-color: #1f1f1f;
-    border: 1px solid rgba(255, 255, 255, 0.1);
 }
 
 .dark-theme .theme-grid {

--- a/styles/shared.css
+++ b/styles/shared.css
@@ -52,6 +52,7 @@
 .grid-theme-item {
     position: relative;
     background: var(--bg-primary);
+    border: 12px solid var(--bg-secondary);
     border-radius: var(--radius-lg);
     overflow: hidden;
     transition: all var(--transition-base);


### PR DESCRIPTION
## Summary
- Added 12px solid borders to all grid-theme-item elements
- Removed conflicting 1px border overrides from dark mode theme styles
- Unified border sizing between theme-grid padding and grid-theme-item borders

Closes #263

🤖 Generated with [Claude Code](https://claude.ai/code)