### PR TITLE
fix: Theme gridの余白を12pxに統一し、背景色を白に変更

### DIFF
--- a/styles/app.css
+++ b/styles/app.css
@@ -800,7 +800,7 @@ main {
 /* ===== テーマグリッド ===== */
 .theme-grid {
     display: grid;
-    gap: 6px;
+    gap: 12px;
     aspect-ratio: 1;
     max-width: 780px;
     width: calc(100% - 32px);
@@ -813,8 +813,8 @@ main {
 
 .grid-theme-item {
     position: relative;
-    background: var(--bg-primary);
-    border: 12px solid var(--bg-secondary);
+    background: white;
+    border: none;
     border-radius: var(--radius-lg);
     overflow: hidden;
     transition: all var(--transition-base);
@@ -1067,6 +1067,10 @@ main {
 /* ダークモード対応 */
 .dark-theme .grid-theme-item.theme-default {
     background-color: #2a2a2a;
+}
+
+.dark-theme .grid-theme-item {
+    background: #1a1a1a;
 }
 
 .dark-theme .grid-theme-item.theme-warm {
@@ -1367,7 +1371,7 @@ main {
         max-width: 780px;
         width: calc(100% - 32px);
         padding: 12px;
-        gap: 6px;
+        gap: 12px;
     }
     
     .action-buttons {
@@ -1382,7 +1386,7 @@ main {
 
 @media (max-width: 480px) {
     .theme-grid {
-        gap: 6px;
+        gap: 12px;
         padding: 12px;
         width: calc(100% - 32px);
         max-width: 780px;


### PR DESCRIPTION
## Summary
- Theme gridのオレンジ色の枠を全て12pxに統一
- 薄いグレーの背景色を白に変更

## Test plan
- [ ] テーマグリッドの表示を確認
- [ ] オレンジ色の枠が全て12pxになっていることを確認
- [ ] 背景色が白になっていることを確認
- [ ] ダークモードでの表示を確認
- [ ] モバイル表示でのレスポンシブ対応を確認

Resolves #266

🤖 Generated with [Claude Code](https://claude.ai/code)