### PR TITLE
fix: ensure equal width for nickname confirmation modal buttons

### DIFF
--- a/styles/app.css
+++ b/styles/app.css
@@ -1210,6 +1210,12 @@ main {
     padding: 0 var(--spacing-6) var(--spacing-6) var(--spacing-6);
 }
 
+/* ニックネーム確認モーダルのボタンを同じ幅に */
+.app-modal-footer .btn {
+    flex: 1;
+    min-width: 120px;
+}
+
 .upload-area {
     border: 2px dashed var(--border-secondary);
     border-radius: var(--radius-lg);


### PR DESCRIPTION
## Summary
• Fixed the nickname confirmation modal buttons to have equal width
• Applied CSS flexbox to distribute space evenly between buttons

## Test plan
• Open the GridMe application
• Complete all grid sections
• Click the share button
• If you have a saved nickname, the confirmation modal will appear
• Verify that both buttons have equal width

Closes #272

🤖 Generated with [Claude Code](https://claude.ai/code)