### PR TITLE
fix: ensure images maintain square aspect ratio when sharing grids

### DIFF
--- a/js/shared-grid.js
+++ b/js/shared-grid.js
@@ -487,7 +487,24 @@
         
         html2canvas(elements.photoThemeGrid, {
             backgroundColor: state.gridBgColor,
-            scale: 2 // 高解像度
+            scale: 2, // 高解像度
+            useCORS: true, // CORS画像のサポート
+            allowTaint: true, // 外部画像の許可
+            logging: false, // デバッグログを無効化
+            imageTimeout: 0, // 画像タイムアウトを無効化
+            onclone: (clonedDoc) => {
+                // クローンされたドキュメントで画像のスタイルを確実に適用
+                const clonedImages = clonedDoc.querySelectorAll('.uploaded-image');
+                clonedImages.forEach(img => {
+                    img.style.objectFit = 'cover';
+                    img.style.objectPosition = 'center';
+                    img.style.width = '100%';
+                    img.style.height = '100%';
+                    img.style.position = 'absolute';
+                    img.style.top = '0';
+                    img.style.left = '0';
+                });
+            }
         }).then(canvas => {
             // 元の背景色に戻す
             elements.photoThemeGrid.style.backgroundColor = originalBg;

--- a/js/theme-grid.js
+++ b/js/theme-grid.js
@@ -356,7 +356,24 @@
         
         html2canvas(elements.themeGrid, {
             backgroundColor: state.gridBgColor,
-            scale: 2 // 高解像度
+            scale: 2, // 高解像度
+            useCORS: true, // CORS画像のサポート
+            allowTaint: true, // 外部画像の許可
+            logging: false, // デバッグログを無効化
+            imageTimeout: 0, // 画像タイムアウトを無効化
+            onclone: (clonedDoc) => {
+                // クローンされたドキュメントで画像のスタイルを確実に適用
+                const clonedImages = clonedDoc.querySelectorAll('.uploaded-image');
+                clonedImages.forEach(img => {
+                    img.style.objectFit = 'cover';
+                    img.style.objectPosition = 'center';
+                    img.style.width = '100%';
+                    img.style.height = '100%';
+                    img.style.position = 'absolute';
+                    img.style.top = '0';
+                    img.style.left = '0';
+                });
+            }
         }).then(canvas => {
             // 元の背景色に戻す
             elements.themeGrid.style.backgroundColor = originalBg;

--- a/js/utils/grid.js
+++ b/js/utils/grid.js
@@ -120,7 +120,24 @@ export class GridRenderer {
         try {
             const canvas = await html2canvas(this.container, {
                 backgroundColor: null,
-                scale: 2 // 高解像度
+                scale: 2, // 高解像度
+                useCORS: true, // CORS画像のサポート
+                allowTaint: true, // 外部画像の許可
+                logging: false, // デバッグログを無効化
+                imageTimeout: 0, // 画像タイムアウトを無効化
+                onclone: (clonedDoc) => {
+                    // クローンされたドキュメントで画像のスタイルを確実に適用
+                    const clonedImages = clonedDoc.querySelectorAll('.uploaded-image');
+                    clonedImages.forEach(img => {
+                        img.style.objectFit = 'cover';
+                        img.style.objectPosition = 'center';
+                        img.style.width = '100%';
+                        img.style.height = '100%';
+                        img.style.position = 'absolute';
+                        img.style.top = '0';
+                        img.style.left = '0';
+                    });
+                }
             });
             
             const dataUrl = canvas.toDataURL('image/png');

--- a/styles/app.css
+++ b/styles/app.css
@@ -1481,6 +1481,32 @@ main {
     border-color: var(--neutral-700);
 }
 
+/* ===== グリッド画像の強制的なアスペクト比維持 ===== */
+/* 全てのグリッド実装で画像が正方形にクロップされるようにする */
+.grid-theme-item .uploaded-image,
+.theme-grid .uploaded-image,
+.photo-theme-grid .uploaded-image {
+    object-fit: cover !important;
+    object-position: center !important;
+    -webkit-object-fit: cover !important;
+    -moz-object-fit: cover !important;
+    -o-object-fit: cover !important;
+}
+
+.grid-theme-item .image-container,
+.theme-grid .image-container,
+.photo-theme-grid .image-container {
+    overflow: hidden !important;
+    aspect-ratio: 1 !important;
+}
+
+.grid-theme-item .photo-display-area,
+.theme-grid .photo-display-area,
+.photo-theme-grid .photo-display-area {
+    aspect-ratio: 1 !important;
+    overflow: hidden !important;
+}
+
 /* ===== 追加のダークモード対応 ===== */
 
 /* メインコンテンツ領域のダークモード */

--- a/styles/shared.css
+++ b/styles/shared.css
@@ -104,6 +104,8 @@
     cursor: pointer;
     transition: all var(--transition-base);
     overflow: hidden;
+    /* Ensure the photo display area maintains square aspect ratio */
+    aspect-ratio: 1;
 }
 
 .photo-display-area.has-image {
@@ -339,12 +341,18 @@
     width: 100%;
     height: 100%;
     object-fit: cover;
+    object-position: center;
     border-radius: var(--radius-lg);
     display: block;
     user-select: none;
     -webkit-user-select: none;
     -moz-user-select: none;
     -ms-user-select: none;
+    /* Force the image to maintain aspect ratio and crop */
+    overflow: hidden;
+    -webkit-object-fit: cover;
+    -moz-object-fit: cover;
+    -o-object-fit: cover;
 }
 
 /* ===== 画像コンテナ ===== */
@@ -352,6 +360,8 @@
     position: relative;
     width: 100%;
     height: 100%;
+    overflow: hidden;
+    border-radius: var(--radius-lg);
 }
 
 /* ===== 画像削除ボタン ===== */


### PR DESCRIPTION
## Summary

This PR fixes the issue where shared grid images were having their aspect ratios changed during download.

## Changes

- Added explicit `object-fit: cover` with vendor prefixes to uploaded images
- Added `object-position: center` to ensure proper centering
- Added `overflow: hidden` to image containers and photo display areas
- Updated html2canvas configuration to properly apply CSS styles during rendering
- Added onclone callback to ensure image styles are maintained in the canvas
- Applied fixes to all grid implementations (shared, theme, and utility)
- Added !important CSS rules to force aspect ratio maintenance

Closes #274

Generated with [Claude Code](https://claude.ai/code)