### PR TITLE
feat: 写真アルバムへの保存機能を実装

### DIFF
--- a/index.html
+++ b/index.html
@@ -148,7 +148,7 @@
     <div id="toast-container"></div>
     
     <!-- JavaScript -->
-    <script type="module" src="js/app.js"></script>
-    <script type="module" src="js/theme-grid.js"></script>
+    <script type="module" src="js/app-refactored.js"></script>
+    <script type="module" src="js/photo-grid-refactored.js"></script>
 </body>
 </html>

--- a/js/shared-grid-refactored.js
+++ b/js/shared-grid-refactored.js
@@ -459,26 +459,35 @@ import { toast, modal, share, GridRenderer, StorageManager, theme } from './util
         }
     }
     
-    // ダウンロード機能
+    // ダウンロード機能（写真アルバムへの保存）
     async function downloadGrid() {
         const filename = `gridme-${new Date().getTime()}.png`;
-        const dataUrl = await gridRenderer.exportAsImage(filename);
         
-        if (dataUrl) {
-            toast.success('ダウンロードを開始しました');
-        } else {
-            // html2canvasライブラリがない場合は動的に読み込む
+        // html2canvasが読み込まれているか確認
+        if (typeof html2canvas === 'undefined') {
+            // html2canvasライブラリを動的に読み込む
             const script = document.createElement('script');
             script.src = 'https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js';
             script.onload = async () => {
-                const dataUrl = await gridRenderer.exportAsImage(filename);
-                if (dataUrl) {
-                    toast.success('ダウンロードを開始しました');
-                } else {
-                    toast.error('ダウンロードに失敗しました');
-                }
+                await performSaveToAlbum(filename);
             };
             document.head.appendChild(script);
+        } else {
+            await performSaveToAlbum(filename);
+        }
+    }
+    
+    // 実際の保存処理
+    async function performSaveToAlbum(filename) {
+        const result = await gridRenderer.saveAsPhoto(filename);
+        
+        if (result === true) {
+            toast.success('画像を保存しました');
+        } else if (result === false) {
+            // ユーザーがキャンセルした場合
+            toast.info('保存をキャンセルしました');
+        } else {
+            toast.error('保存に失敗しました');
         }
     }
     

--- a/js/utils/grid.js
+++ b/js/utils/grid.js
@@ -157,6 +157,72 @@ export class GridRenderer {
         }
     }
 
+    // グリッドを写真として保存（写真アルバムへ）
+    async saveAsPhoto(filename = 'grid.png') {
+        if (typeof html2canvas === 'undefined') {
+            console.error('html2canvas library is required for export');
+            return null;
+        }
+
+        try {
+            const canvas = await html2canvas(this.container, {
+                backgroundColor: null,
+                scale: 2, // 高解像度
+                useCORS: true, // CORS画像のサポート
+                allowTaint: true, // 外部画像の許可
+                logging: false, // デバッグログを無効化
+                imageTimeout: 0, // 画像タイムアウトを無効化
+                onclone: (clonedDoc) => {
+                    // クローンされたドキュメントで画像のスタイルを確実に適用
+                    const clonedImages = clonedDoc.querySelectorAll('.uploaded-image');
+                    clonedImages.forEach(img => {
+                        img.style.objectFit = 'cover';
+                        img.style.objectPosition = 'center';
+                        img.style.width = '100%';
+                        img.style.height = '100%';
+                        img.style.position = 'absolute';
+                        img.style.top = '0';
+                        img.style.left = '0';
+                    });
+                }
+            });
+            
+            // CanvasをBlobに変換
+            const blob = await new Promise(resolve => canvas.toBlob(resolve, 'image/png'));
+            
+            // Web Share APIをサポートしているかチェック
+            if (navigator.share && navigator.canShare && navigator.canShare({ files: [new File([blob], filename, { type: 'image/png' })] })) {
+                // Web Share APIを使用して写真を共有（モバイルでは写真アルバムに保存可能）
+                const file = new File([blob], filename, { type: 'image/png' });
+                try {
+                    await navigator.share({
+                        files: [file],
+                        title: 'GridMe',
+                        text: 'GridMeで作成した画像'
+                    });
+                    return true;
+                } catch (err) {
+                    // ユーザーがキャンセルした場合
+                    if (err.name === 'AbortError') {
+                        return false;
+                    }
+                    throw err;
+                }
+            } else {
+                // Web Share APIがサポートされていない場合は従来のダウンロード
+                const dataUrl = canvas.toDataURL('image/png');
+                const link = document.createElement('a');
+                link.download = filename;
+                link.href = dataUrl;
+                link.click();
+                return true;
+            }
+        } catch (error) {
+            console.error('Save as photo error:', error);
+            return null;
+        }
+    }
+
     // グリッドデータを取得
     getGridData() {
         return {

--- a/shared.html
+++ b/shared.html
@@ -133,11 +133,11 @@
                     </button>
                     <button class="share-option-btn" id="download-grid-btn">
                         <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                            <path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/>
-                            <polyline points="7 10 12 15 17 10"/>
-                            <line x1="12" y1="15" x2="12" y2="3"/>
+                            <rect x="3" y="3" width="18" height="18" rx="2" ry="2"/>
+                            <circle cx="8.5" cy="8.5" r="1.5"/>
+                            <polyline points="21 15 16 10 5 21"/>
                         </svg>
-                        <span>グリッドをダウンロード</span>
+                        <span>写真に追加</span>
                     </button>
                 </div>
                 <div class="share-url-preview">
@@ -151,7 +151,7 @@
     <div id="toast-container"></div>
     
     <!-- JavaScript -->
-    <script type="module" src="js/app.js"></script>
-    <script type="module" src="js/shared-grid.js"></script>
+    <script type="module" src="js/app-refactored.js"></script>
+    <script type="module" src="js/shared-grid-refactored.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Web Share APIを使用してモバイルデバイスで写真アプリに直接保存可能に
- デスクトップでは従来通りダウンロードとして保存
- ボタンのテキストとアイコンを「写真に追加」に変更

Fixes #279

Generated with [Claude Code](https://claude.ai/code)