### PR TITLE
fix: theme-gridの白い枠だけの表示問題を修正

### DIFF
--- a/styles/app.css
+++ b/styles/app.css
@@ -813,8 +813,8 @@ main {
 
 .grid-theme-item {
     position: relative;
-    background: white;
-    border: none;
+    background: var(--bg-primary);
+    border: 1px solid var(--border-primary);
     border-radius: var(--radius-lg);
     overflow: hidden;
     transition: all var(--transition-base);
@@ -853,7 +853,7 @@ main {
     font-family: inherit;
     transition: all var(--transition-base);
     background: transparent;
-    color: var(--text-secondary);
+    color: var(--text-primary);
     resize: none;
     overflow: hidden;
     line-height: 1.4;
@@ -869,7 +869,12 @@ main {
 .section-title-input:focus {
     outline: none;
     box-shadow: none;
-    background: var(--bg-primary); /* Use theme-aware background */
+    background: transparent;
+}
+
+.section-title-input::placeholder {
+    color: var(--text-tertiary);
+    opacity: 1;
 }
 
 /* セクションテーマ選択 */


### PR DESCRIPTION
## Summary
- grid-theme-itemの背景色を適切に設定して白い枠のみの表示を修正
- テキストとプレースホルダーの視認性を向上

## Test plan
- メインページでtheme-gridが正しく表示されることを確認
- テーマ入力欄が見えることを確認
- ダークモードでも正しく表示されることを確認

Closes #281

🤖 Generated with [Claude Code](https://claude.ai/code)