### PR TITLE
feat: テーマ入力フィールドの動的高さ調整

### DIFF
--- a/js/theme-grid.js
+++ b/js/theme-grid.js
@@ -119,10 +119,13 @@
         titleInput.value = section.title;
         titleInput.dataset.index = index;
         titleInput.dataset.field = 'title';
-        titleInput.rows = 2;
+        titleInput.rows = 1;
         
         // イベントリスナーの追加
-        titleInput.addEventListener('input', handleSectionUpdate);
+        titleInput.addEventListener('input', (e) => {
+            handleSectionUpdate(e);
+            adjustTextareaHeight(e.target);
+        });
         titleInput.addEventListener('focus', () => {
             state.currentFocusedInput = titleInput;
         });
@@ -138,7 +141,32 @@
         // 要素の組み立て - テキストのみ追加
         gridItem.appendChild(titleInput);
         
+        // 初期コンテンツがある場合は高さを調整
+        if (section.title) {
+            setTimeout(() => adjustTextareaHeight(titleInput), 0);
+        }
+        
         return gridItem;
+    }
+    
+    // テキストエリアの高さを自動調整
+    function adjustTextareaHeight(textarea) {
+        // 一旦高さをリセット
+        textarea.style.height = '2.2em';
+        
+        // スクロール高さを取得
+        const scrollHeight = textarea.scrollHeight;
+        const lineHeight = parseFloat(window.getComputedStyle(textarea).lineHeight);
+        const padding = parseFloat(window.getComputedStyle(textarea).paddingTop) + 
+                       parseFloat(window.getComputedStyle(textarea).paddingBottom);
+        
+        // 2行分の高さを計算（行の高さ × 2 + パディング）
+        const twoLinesHeight = (lineHeight * 2) + padding;
+        
+        // 内容が1行を超える場合は2行分の高さに設定
+        if (scrollHeight > textarea.offsetHeight) {
+            textarea.style.height = Math.min(scrollHeight, twoLinesHeight) + 'px';
+        }
     }
     
     // セクション更新ハンドラー
@@ -570,6 +598,8 @@
                 // イベントを手動でトリガー
                 const event = new Event('input', { bubbles: true });
                 state.currentFocusedInput.dispatchEvent(event);
+                // 高さも調整
+                adjustTextareaHeight(state.currentFocusedInput);
                 state.currentFocusedInput.focus();
             } else {
                 showToast('まずテーマ入力欄をクリックしてください', 'info');

--- a/styles/app.css
+++ b/styles/app.css
@@ -862,10 +862,12 @@ main {
     line-height: 1.4;
     text-align: center;
     margin-bottom: var(--spacing-2);
-    min-height: 2.4em;
+    height: 2.2em; /* デフォルトは1行分の高さ */
     vertical-align: middle;
     display: block;
     margin: auto;
+    overflow-wrap: break-word; /* 長い単語を折り返す */
+    word-wrap: break-word; /* 古いブラウザ対応 */
 }
 
 .section-title-input:focus {

--- a/test-dynamic-textarea.html
+++ b/test-dynamic-textarea.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Test Dynamic Textarea</title>
+    <link rel="stylesheet" href="styles/design-tokens.css">
+    <link rel="stylesheet" href="styles/components.css">
+    <link rel="stylesheet" href="styles/app.css">
+    <style>
+        body {
+            padding: 20px;
+        }
+        .test-container {
+            max-width: 300px;
+            margin: 0 auto;
+            background: #f0f0f0;
+            padding: 20px;
+            border-radius: 8px;
+        }
+        .test-grid-item {
+            background: white;
+            padding: 10px;
+            border-radius: 8px;
+            margin-bottom: 20px;
+        }
+    </style>
+</head>
+<body>
+    <div class="test-container">
+        <h2>Dynamic Textarea Test</h2>
+        <div class="test-grid-item">
+            <textarea class="section-title-input" placeholder="短いテキスト" rows="1"></textarea>
+        </div>
+        <div class="test-grid-item">
+            <textarea class="section-title-input" placeholder="長いテキストを入力してください" rows="1">これは長いテキストの例です。一行に収まらない場合は自動的に二行に拡張されます。</textarea>
+        </div>
+    </div>
+    
+    <script>
+        // テキストエリアの高さを自動調整
+        function adjustTextareaHeight(textarea) {
+            // 一旦高さをリセット
+            textarea.style.height = '2.2em';
+            
+            // スクロール高さを取得
+            const scrollHeight = textarea.scrollHeight;
+            const lineHeight = parseFloat(window.getComputedStyle(textarea).lineHeight);
+            const padding = parseFloat(window.getComputedStyle(textarea).paddingTop) + 
+                           parseFloat(window.getComputedStyle(textarea).paddingBottom);
+            
+            // 2行分の高さを計算（行の高さ × 2 + パディング）
+            const twoLinesHeight = (lineHeight * 2) + padding;
+            
+            // 内容が1行を超える場合は2行分の高さに設定
+            if (scrollHeight > textarea.offsetHeight) {
+                textarea.style.height = Math.min(scrollHeight, twoLinesHeight) + 'px';
+            }
+        }
+        
+        // すべてのテキストエリアに対してイベントリスナーを設定
+        document.querySelectorAll('.section-title-input').forEach(textarea => {
+            textarea.addEventListener('input', (e) => {
+                adjustTextareaHeight(e.target);
+            });
+            
+            // 初期コンテンツがある場合は高さを調整
+            if (textarea.value) {
+                setTimeout(() => adjustTextareaHeight(textarea), 0);
+            }
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- テーマ入力フィールドがデフォルトで1行表示で、必要に応じて2行に拡張するように変更
- 自動高さ調整機能をJavaScriptで実装

## Test plan
- [ ] 短いテキストを入力して、1行のままであることを確認
- [ ] 長いテキストを入力して、2行に拡張されることを確認
- [ ] テーマチップをクリックしても正しく高さが調整されることを確認

Closes #285

🤖 Generated with [Claude Code](https://claude.ai/code)