### PR TITLE
fix: set header margin to 12px

### DIFF
--- a/styles/app.css
+++ b/styles/app.css
@@ -564,7 +564,7 @@ main {
     background: color-mix(in srgb, var(--bg-primary) 90%, transparent);
     backdrop-filter: blur(10px);
     padding: var(--spacing-1) 0;
-    margin-bottom: 0;
+    margin: 12px;
 }
 
 /* ダークモード時のヘッダー背景を黒に */


### PR DESCRIPTION
## Summary

As requested in issue #288, updated the .app-header margin to 12px.

## Changes
- Changed `.app-header` margin from `margin-bottom: 0` to `margin: 12px` in `styles/app.css`

Closes #288

Generated with [Claude Code](https://claude.ai/code)