### PR TITLE
fix: sharedページのtheme grid表示問題を修正

### DIFF
--- a/styles/shared.css
+++ b/styles/shared.css
@@ -83,6 +83,7 @@
     align-items: center;
     justify-content: center;
     background: transparent;
+    min-height: 60px; /* 最小高さを確保 */
 }
 
 /* 共有セクションタイトル - 削除: グリッドテーマテキストで統一 */
@@ -93,11 +94,10 @@
 
 /* ===== 写真表示エリア ===== */
 .photo-display-area {
-    position: absolute;
-    top: 0;
-    left: 0;
+    position: relative; /* absoluteからrelativeに変更 */
     width: 100%;
     height: 100%;
+    min-height: 60px; /* 最小高さを確保 */
     background: transparent;
     border: none;
     border-radius: var(--radius-lg);
@@ -135,13 +135,6 @@
     transform: scale(1.1);
 }
 
-/* アップロードされた画像 */
-.uploaded-image {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-    border-radius: var(--radius-lg);
-}
 
 /* 画像がある場合のグリッドアイテム */
 .grid-theme-item.has-image {
@@ -338,9 +331,6 @@
 
 /* ===== アップロードされた画像 ===== */
 .uploaded-image {
-    position: absolute;
-    top: 0;
-    left: 0;
     width: 100%;
     height: 100%;
     object-fit: cover;


### PR DESCRIPTION
## 概要

sharedページのtheme gridで枠しか見えない問題を修正しました。

## 変更内容
- grid-section-containerに最小高さを追加
- photo-display-areaのpositionをabsoluteからrelativeに変更
- 重複したuploaded-imageスタイルを削除

Closes #291

Generated with [Claude Code](https://claude.ai/code)