### PR TITLE
fix: duplicate export of ThemeManager in theme.js

### DIFF
--- a/js/utils/index.js
+++ b/js/utils/index.js
@@ -5,7 +5,8 @@
  */
 
 export { toast, ToastManager } from './toast.js';
-export { theme, ThemeManager } from './theme.js';
+export { theme } from './theme.js';
+export { ThemeManager } from './theme.js';
 export { modal, ModalManager } from './modal.js';
 export { storage, StorageManager, Storage } from './storage.js';
 export { share, ShareManager } from './share.js';

--- a/js/utils/theme.js
+++ b/js/utils/theme.js
@@ -186,4 +186,3 @@ export class ThemeManager {
 
 // デフォルトインスタンスをエクスポート
 export const theme = new ThemeManager();
-export { ThemeManager };


### PR DESCRIPTION
## Summary
- Fixed duplicate export of ThemeManager causing syntax error
- Updated module exports in index.js to avoid conflicts
- This resolves the theme grid display issue on shared page

## Test plan
- [ ] Verify no console errors on shared.html page
- [ ] Check that theme grid displays correctly
- [ ] Test dark mode toggle functionality

Closes #297

🤖 Generated with [Claude Code](https://claude.ai/code)