### PR TITLE
fix: make theme-text background transparent on shared page

### DIFF
--- a/styles/shared.css
+++ b/styles/shared.css
@@ -267,6 +267,7 @@
     /* テーマテキスト */
     .theme-text {
         color: var(--text-primary);
+        background: transparent;
     }
     
     /* セクションタイトル */
@@ -290,6 +291,7 @@
     /* テーマテキスト */
     .theme-text {
         color: var(--text-secondary);
+        background: transparent;
     }
 }
 
@@ -311,7 +313,7 @@
     padding: var(--spacing-2);
     margin-bottom: var(--spacing-3);
     text-align: center;
-    background: rgba(0, 0, 0, 0.05);
+    background: transparent;
     border-radius: var(--radius-md);
     line-height: 1.4;
 }
@@ -319,7 +321,7 @@
 /* ダークモード時のテーマテキスト */
 .dark-theme .theme-text {
     color: var(--text-primary);
-    background: rgba(255, 255, 255, 0.1);
+    background: transparent;
 }
 
 /* ===== グリッドボタン ===== */


### PR DESCRIPTION
## Summary
- Made theme-text background transparent to match page background
- Updated both light and dark mode styles

## Changes
- Changed `.theme-text` background from semi-transparent to fully transparent
- Ensured consistency across all theme modes

Closes #299

Generated with [Claude Code](https://claude.ai/code)