### PR TITLE
Fix plus icon visibility issue in small grids

### DIFF
--- a/styles/shared.css
+++ b/styles/shared.css
@@ -60,7 +60,7 @@
     flex-direction: column;
     align-items: center;
     justify-content: flex-start;
-    padding: var(--spacing-3);
+    padding: var(--spacing-2);
     min-height: 100px;
     aspect-ratio: 1;
     width: 100%;
@@ -83,7 +83,7 @@
     align-items: center;
     justify-content: center;
     background: transparent;
-    min-height: 60px; /* 最小高さを確保 */
+    min-height: 40px; /* 最小高さを調整 */
 }
 
 /* 共有セクションタイトル - 削除: グリッドテーマテキストで統一 */
@@ -124,8 +124,8 @@
 
 /* プラスアイコン */
 .add-photo-icon {
-    width: 32px;
-    height: 32px;
+    width: 28px;
+    height: 28px;
     color: var(--text-tertiary);
     transition: all var(--transition-base);
 }
@@ -311,11 +311,15 @@
     font-weight: var(--font-semibold);
     color: var(--text-primary);
     padding: var(--spacing-2);
-    margin-bottom: var(--spacing-3);
+    margin-bottom: var(--spacing-2);
     text-align: center;
     background: transparent;
     border-radius: var(--radius-md);
-    line-height: 1.4;
+    line-height: 1.2;
+    /* 長いテキストの場合は省略表示 */
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 /* ダークモード時のテーマテキスト */
@@ -502,5 +506,60 @@
     
     .grid-theme-item {
         min-height: 80px;
+        padding: var(--spacing-1);
     }
+    
+    .theme-text {
+        font-size: var(--text-sm);
+        padding: var(--spacing-1);
+        margin-bottom: var(--spacing-1);
+    }
+    
+    .add-photo-icon {
+        width: 24px;
+        height: 24px;
+    }
+}
+
+/* ===== 3x3グリッド専用スタイル ===== */
+#photo-theme-grid[style*="repeat(3,"] .grid-theme-item {
+    padding: var(--spacing-1);
+}
+
+#photo-theme-grid[style*="repeat(3,"] .theme-text {
+    font-size: var(--text-sm);
+    padding: var(--spacing-1);
+    margin-bottom: var(--spacing-1);
+    line-height: 1.1;
+}
+
+#photo-theme-grid[style*="repeat(3,"] .add-photo-icon {
+    width: 24px;
+    height: 24px;
+}
+
+#photo-theme-grid[style*="repeat(3,"] .grid-section-container {
+    min-height: 30px;
+}
+
+/* ===== 4x4グリッド専用スタイル ===== */
+#photo-theme-grid[style*="repeat(4,"] .grid-theme-item {
+    padding: 6px;
+    min-height: 70px;
+}
+
+#photo-theme-grid[style*="repeat(4,"] .theme-text {
+    font-size: 11px;
+    padding: 4px;
+    margin-bottom: 4px;
+    line-height: 1;
+}
+
+#photo-theme-grid[style*="repeat(4,"] .add-photo-icon {
+    width: 20px;
+    height: 20px;
+}
+
+#photo-theme-grid[style*="repeat(4,"] .grid-section-container {
+    min-height: 25px;
 }


### PR DESCRIPTION
Fixes #301

## Summary
Fixed the issue where the plus icon was hidden by the theme text box when the grid size was small.

## Changes
- Reduced padding and margins for theme text and grid items
- Added text ellipsis for long theme texts to save space
- Adjusted icon sizes for better fit
- Added specific styles for 3x3 and 4x4 grids with more compact spacing

Generated with [Claude Code](https://claude.ai/code)