### PR TITLE
fix: update theme grid styling for 3x3 grids

### DIFF
--- a/styles/app.css
+++ b/styles/app.css
@@ -800,13 +800,13 @@ main {
 /* ===== テーマグリッド ===== */
 .theme-grid {
     display: grid;
-    gap: 12px;
+    gap: 8px;
     aspect-ratio: 1;
     max-width: 780px;
     width: calc(100% - 32px);
     margin: 0 auto;
     background: #FF8B25;
-    padding: 12px;
+    padding: 8px;
     border-radius: var(--radius-xl);
     box-shadow: var(--shadow-xl);
 }
@@ -814,7 +814,7 @@ main {
 .grid-theme-item {
     position: relative;
     background: rgba(255, 255, 255, 0.95);
-    border: 2px solid rgba(0, 0, 0, 0.1);
+    border: none;
     border-radius: var(--radius-lg);
     overflow: hidden;
     transition: all var(--transition-base);
@@ -1386,8 +1386,8 @@ main {
     .theme-grid {
         max-width: 780px;
         width: calc(100% - 32px);
-        padding: 12px;
-        gap: 12px;
+        padding: 8px;
+        gap: 8px;
     }
     
     .action-buttons {
@@ -1402,8 +1402,8 @@ main {
 
 @media (max-width: 480px) {
     .theme-grid {
-        gap: 12px;
-        padding: 12px;
+        gap: 8px;
+        padding: 8px;
         width: calc(100% - 32px);
         max-width: 780px;
     }
@@ -1521,6 +1521,21 @@ main {
 .photo-theme-grid .photo-display-area {
     aspect-ratio: 1 !important;
     overflow: hidden !important;
+}
+
+/* 画像がある場合、グリッドアイテムのパディングを削除して画像で埋める */
+.grid-theme-item.has-image {
+    padding: 0 !important;
+}
+
+.grid-theme-item.has-image .image-container,
+.grid-theme-item.has-image .photo-display-area {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    border-radius: var(--radius-lg);
 }
 
 /* ===== 追加のダークモード対応 ===== */

--- a/styles/shared.css
+++ b/styles/shared.css
@@ -37,13 +37,13 @@
 /* ===== フォトテーマグリッド ===== */
 #photo-theme-grid {
     display: grid;
-    gap: 12px;
+    gap: 8px;
     aspect-ratio: 1;
     max-width: 780px;
     width: calc(100% - 32px);
     margin: 0 auto var(--spacing-6) auto;
     background: var(--bg-secondary);
-    padding: 12px;
+    padding: 8px;
     border-radius: var(--radius-xl);
     box-shadow: var(--shadow-xl);
 }
@@ -52,7 +52,7 @@
 .grid-theme-item {
     position: relative;
     background: rgba(255, 255, 255, 0.95);
-    border: 2px solid rgba(0, 0, 0, 0.1);
+    border: none;
     border-radius: var(--radius-lg);
     overflow: hidden;
     transition: all var(--transition-base);
@@ -204,32 +204,32 @@
 
 .dark-theme .photo-theme-item.theme-default {
     background-color: #2a2a2a;
-    border: 1px solid rgba(255, 255, 255, 0.1);
+    border: none;
 }
 
 .dark-theme .photo-theme-item.theme-warm {
     background-color: #3d2820;
-    border: 1px solid rgba(255, 139, 37, 0.2);
+    border: none;
 }
 
 .dark-theme .photo-theme-item.theme-cool {
     background-color: #202838;
-    border: 1px solid rgba(6, 182, 212, 0.2);
+    border: none;
 }
 
 .dark-theme .photo-theme-item.theme-nature {
     background-color: #1a2f1a;
-    border: 1px solid rgba(16, 185, 129, 0.2);
+    border: none;
 }
 
 .dark-theme .photo-theme-item.theme-elegant {
     background-color: #2f1a3d;
-    border: 1px solid rgba(139, 92, 246, 0.2);
+    border: none;
 }
 
 .dark-theme .photo-theme-item.theme-modern {
     background-color: #1f1f1f;
-    border: 1px solid rgba(255, 255, 255, 0.1);
+    border: none;
 }
 
 .dark-theme .photo-theme-grid {
@@ -477,8 +477,8 @@
     .theme-grid {
         max-width: 780px;
         width: calc(100% - 32px);
-        padding: 12px;
-        gap: 12px;
+        padding: 8px;
+        gap: 8px;
     }
     
     .shared-actions {
@@ -494,8 +494,8 @@
 
 @media (max-width: 480px) {
     .theme-grid {
-        gap: 12px;
-        padding: 12px;
+        gap: 8px;
+        padding: 8px;
         width: calc(100% - 32px);
         max-width: 780px;
     }


### PR DESCRIPTION
## Summary
• Updated grid gap from 12px to 8px for all theme grids
• Removed borders from grid items for cleaner appearance
• Made images fill entire grid boxes when displayed

Closes #303

Generated with [Claude Code](https://claude.ai/code)