### PR TITLE
fix: remove photo backgrounds and improve text contrast on theme-grid page

### DIFF
--- a/styles/theme-grid.css
+++ b/styles/theme-grid.css
@@ -55,7 +55,7 @@
 
 /* カードの表面（画像） */
 .flip-card-front {
-    background: var(--bg-secondary);
+    background: transparent;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -69,7 +69,7 @@
 
 /* カードの裏面（テーマテキスト） */
 .flip-card-back {
-    background: linear-gradient(135deg, var(--primary) 0%, var(--primary-dark) 100%);
+    background: linear-gradient(135deg, var(--primary-dark) 0%, var(--neutral-900) 100%);
     color: white;
     transform: rotateY(180deg);
     display: flex;
@@ -77,6 +77,7 @@
     justify-content: center;
     padding: 1rem;
     text-align: center;
+    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
 }
 
 .theme-display-text {
@@ -157,8 +158,8 @@
 
 /* エラー状態 */
 .flip-card.error .flip-card-front {
-    background: var(--bg-error);
-    color: var(--text-error);
+    background: transparent;
+    color: var(--error);
 }
 
 .flip-card.error .flip-card-front::before {


### PR DESCRIPTION
## Summary

This PR addresses the styling issues on the theme-grid page:

- Removes gray background from photo containers to match index and shared pages
- Improves text contrast on flipped cards for better readability

## Changes

1. **Photo backgrounds**: Changed from `var(--bg-secondary)` to `transparent`
2. **Flipped card contrast**: 
   - Updated gradient to use darker colors
   - Added text shadow for enhanced visibility
3. **Error state**: Updated to use transparent background for consistency

Resolves #315

Generated with [Claude Code](https://claude.ai/code)