### PR TITLE
fix: add share modal to theme-grid page download button

### DIFF
--- a/js/theme-grid-view.js
+++ b/js/theme-grid-view.js
@@ -20,7 +20,14 @@
     const elements = {
         viewThemeGrid: document.getElementById('view-theme-grid'),
         downloadBtn: document.getElementById('download-grid-btn'),
-        createNewBtn: document.getElementById('create-new-btn')
+        createNewBtn: document.getElementById('create-new-btn'),
+        shareModal: document.getElementById('share-modal'),
+        shareModalClose: null,
+        copyUrlBtn: document.getElementById('copy-url-btn'),
+        shareTwitterBtn: document.getElementById('share-twitter-btn'),
+        shareLineBtn: document.getElementById('share-line-btn'),
+        shareUrlInput: document.getElementById('share-url-input'),
+        downloadImageBtn: document.getElementById('download-image-btn')
     };
     
     // URLパラメータからデータを取得
@@ -276,11 +283,62 @@
         }
     }
     
+    // 共有モーダルを表示
+    function showShareModal() {
+        if (!elements.shareModal) return;
+        
+        // 現在のURLを設定
+        const currentUrl = window.location.href;
+        if (elements.shareUrlInput) {
+            elements.shareUrlInput.value = currentUrl;
+        }
+        
+        elements.shareModal.classList.add('active');
+    }
+    
+    // 共有モーダルを閉じる
+    function closeShareModal() {
+        if (elements.shareModal) {
+            elements.shareModal.classList.remove('active');
+        }
+    }
+    
+    // URLをコピー
+    async function copyShareUrl() {
+        const shareUrl = elements.shareUrlInput?.value || window.location.href;
+        
+        try {
+            await navigator.clipboard.writeText(shareUrl);
+            showToast('URLをコピーしました', 'success');
+        } catch (err) {
+            console.error('コピーエラー:', err);
+            showToast('URLのコピーに失敗しました', 'error');
+        }
+    }
+    
+    // Twitterで共有
+    function shareOnTwitter() {
+        const shareUrl = elements.shareUrlInput?.value || window.location.href;
+        const nickname = state.nickname ? `${state.nickname}の` : '';
+        const text = encodeURIComponent(`${nickname}GridMe!!どんな感じ？`);
+        const twitterUrl = `https://twitter.com/intent/tweet?text=${text}&url=${encodeURIComponent(shareUrl)}`;
+        window.open(twitterUrl, '_blank', 'width=600,height=400');
+    }
+    
+    // LINEで共有
+    function shareOnLine() {
+        const shareUrl = elements.shareUrlInput?.value || window.location.href;
+        const nickname = state.nickname ? `${state.nickname}の` : '';
+        const text = encodeURIComponent(`${nickname}GridMe!!どんな感じ？`);
+        const lineUrl = `https://social-plugins.line.me/lineit/share?url=${encodeURIComponent(shareUrl)}&text=${text}`;
+        window.open(lineUrl, '_blank', 'width=600,height=400');
+    }
+    
     // イベントリスナーの設定
     function setupEventListeners() {
-        // ダウンロードボタン
+        // ダウンロードボタン（共有モーダルを表示）
         if (elements.downloadBtn) {
-            elements.downloadBtn.addEventListener('click', downloadGrid);
+            elements.downloadBtn.addEventListener('click', showShareModal);
         }
         
         // 新規作成ボタン
@@ -288,6 +346,41 @@
             elements.createNewBtn.addEventListener('click', () => {
                 window.location.href = './index.html';
             });
+        }
+        
+        // モーダル関連
+        if (elements.shareModal) {
+            // モーダルの閉じるボタンを取得
+            elements.shareModalClose = elements.shareModal.querySelector('.app-modal-close');
+            
+            // モーダルを閉じる
+            if (elements.shareModalClose) {
+                elements.shareModalClose.addEventListener('click', closeShareModal);
+            }
+            
+            // モーダル背景クリックで閉じる
+            elements.shareModal.addEventListener('click', (e) => {
+                if (e.target === elements.shareModal) {
+                    closeShareModal();
+                }
+            });
+        }
+        
+        // 共有オプションボタン
+        if (elements.downloadImageBtn) {
+            elements.downloadImageBtn.addEventListener('click', () => {
+                closeShareModal();
+                downloadGrid();
+            });
+        }
+        if (elements.copyUrlBtn) {
+            elements.copyUrlBtn.addEventListener('click', copyShareUrl);
+        }
+        if (elements.shareTwitterBtn) {
+            elements.shareTwitterBtn.addEventListener('click', shareOnTwitter);
+        }
+        if (elements.shareLineBtn) {
+            elements.shareLineBtn.addEventListener('click', shareOnLine);
         }
     }
     

--- a/theme-grid.html
+++ b/theme-grid.html
@@ -73,6 +73,55 @@
         </div>
     </footer>
     
+    <!-- 共有モーダル -->
+    <div class="app-modal" id="share-modal">
+        <div class="app-modal-content card-glass" style="max-width: 400px;">
+            <div class="app-modal-header">
+                <h3>Gridをシェアする</h3>
+                <button class="btn-icon app-modal-close" aria-label="閉じる">
+                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <line x1="18" y1="6" x2="6" y2="18"/>
+                        <line x1="6" y1="6" x2="18" y2="18"/>
+                    </svg>
+                </button>
+            </div>
+            <div class="app-modal-body">
+                <div class="share-options">
+                    <button class="share-option-btn" id="download-image-btn">
+                        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/>
+                            <polyline points="7 10 12 15 17 10"/>
+                            <line x1="12" y1="15" x2="12" y2="3"/>
+                        </svg>
+                        <span>画像をダウンロード</span>
+                    </button>
+                    <button class="share-option-btn" id="copy-url-btn">
+                        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <rect x="9" y="9" width="13" height="13" rx="2" ry="2"/>
+                            <path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/>
+                        </svg>
+                        <span>URLをコピー</span>
+                    </button>
+                    <button class="share-option-btn" id="share-twitter-btn">
+                        <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+                            <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
+                        </svg>
+                        <span>X (Twitter)</span>
+                    </button>
+                    <button class="share-option-btn" id="share-line-btn">
+                        <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+                            <path d="M19.365 9.863c.349 0 .63.285.63.631 0 .345-.281.63-.63.63H17.61v1.125h1.755c.349 0 .63.283.63.63 0 .344-.281.629-.63.629h-2.386c-.345 0-.627-.285-.627-.629V8.108c0-.345.282-.63.63-.63h2.386c.346 0 .627.285.627.63 0 .349-.281.63-.63.63H17.61v1.125h1.755zm-3.855 3.016c0 .27-.174.51-.432.596-.064.021-.133.031-.199.031-.211 0-.391-.09-.51-.25l-2.443-3.317v2.94c0 .344-.279.629-.631.629-.346 0-.626-.285-.626-.629V8.108c0-.27.173-.51.43-.595.06-.023.136-.033.194-.033.195 0 .375.104.495.254l2.462 3.33V8.108c0-.345.282-.63.63-.63.345 0 .63.285.63.63v4.771zm-5.741 0c0 .344-.282.629-.631.629-.345 0-.627-.285-.627-.629V8.108c0-.345.282-.63.627-.63.349 0 .631.285.631.63v4.771zm-2.466.629H4.917c-.345 0-.63-.285-.63-.629V8.108c0-.345.285-.63.63-.63.349 0 .63.285.63.63v4.141h1.756c.348 0 .629.283.629.63 0 .344-.282.629-.629.629M24 10.314C24 4.943 18.615.572 12 .572S0 4.943 0 10.314c0 4.811 4.27 8.842 10.035 9.608.391.082.923.258 1.058.59.12.301.079.766.038 1.08l-.164 1.02c-.045.301-.24 1.186 1.049.645 1.291-.539 6.916-4.078 9.436-6.975C23.176 14.393 24 12.458 24 10.314"/>
+                        </svg>
+                        <span>LINE</span>
+                    </button>
+                </div>
+                <div class="share-url-preview">
+                    <input type="text" id="share-url-input" class="input" readonly>
+                </div>
+            </div>
+        </div>
+    </div>
+
     <!-- トースト通知コンテナ -->
     <div id="toast-container"></div>
     


### PR DESCRIPTION
Issue #316 の修正

## 変更内容
- theme-gridページのダウンロードボタンに共有モーダルを追加
- 画像のダウンロード、URLコピー、SNS共有機能を実装

Generated with [Claude Code](https://claude.ai/code)