### PR TITLE
fix: Remove grid-theme-item padding and update flip-card styles

### DIFF
--- a/styles/app.css
+++ b/styles/app.css
@@ -822,7 +822,6 @@ main {
     flex-direction: column;
     align-items: center;
     justify-content: flex-start;
-    padding: var(--spacing-3);
     min-height: 100px;
     aspect-ratio: 1;
     width: 100%;

--- a/styles/theme-grid.css
+++ b/styles/theme-grid.css
@@ -69,19 +69,18 @@
 
 /* カードの裏面（テーマテキスト） */
 .flip-card-back {
-    background: linear-gradient(135deg, var(--primary-dark) 0%, var(--neutral-900) 100%);
-    color: white;
+    background: #ffffff;
+    color: #000000;
     transform: rotateY(180deg);
     display: flex;
     align-items: center;
     justify-content: center;
     padding: 1rem;
     text-align: center;
-    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
 }
 
 .theme-display-text {
-    font-size: 1.25rem;
+    font-size: 14px;
     font-weight: 600;
     line-height: 1.4;
     word-break: break-word;


### PR DESCRIPTION
## Summary

This PR implements the styling changes requested in #321:

- Removed padding from grid-theme-item elements in the theme-grid page
- Updated flip-card flipped state with white background and black text
- Set text size to 14px for better readability

Fixes #321

Generated with [Claude Code](https://claude.ai/code)