### PR TITLE
style: テーマテキストボックスに左右8pxのマージンを追加

### DIFF
--- a/styles/app.css
+++ b/styles/app.css
@@ -846,7 +846,7 @@ main {
 
 /* セクションタイトル入力 */
 .section-title-input {
-    width: 100%;
+    width: calc(100% - 16px);
     border: 1px solid rgba(0, 0, 0, 0.1);
     border-radius: var(--radius-md);
     padding: var(--spacing-2) var(--spacing-2);
@@ -864,7 +864,7 @@ main {
     height: 2.2em; /* デフォルトは1行分の高さ */
     vertical-align: middle;
     display: block;
-    margin: auto;
+    margin: 0 8px;
     overflow-wrap: break-word; /* 長い単語を折り返す */
     word-wrap: break-word; /* 古いブラウザ対応 */
 }


### PR DESCRIPTION
## 概要

インデックスページのグリッド内のテーマテキストボックスに左右8pxのマージンを追加しました。

## 変更内容

- `section-title-input`のwidthを100%からcalc(100% - 16px)に変更
- marginを"auto"から"0 8px"に変更

Closes #2327

Generated with [Claude Code](https://claude.ai/code)