### PR TITLE
feat: theme-grid pageに写真アルバムへの保存機能を実装

### DIFF
--- a/theme-grid.html
+++ b/theme-grid.html
@@ -127,6 +127,6 @@
     
     <!-- JavaScript -->
     <script src="js/app.js"></script>
-    <script src="js/theme-grid-view.js"></script>
+    <script type="module" src="js/theme-grid-view.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- theme-grid.htmlページに「写真をアルバムに保存」機能を追加
- GridRendererモジュールを使用してshared pageと同じ保存機能を実装
- Web Share APIによるモバイルでの写真アルバムへの保存に対応

Closes #336

## Test plan
- [ ] theme-grid.htmlページを開く
- [ ] 「画像をダウンロード」ボタンをクリック
- [ ] モーダルから「画像をダウンロード」を選択
- [ ] モバイルでは写真アルバムに保存されることを確認
- [ ] デスクトップではダウンロードされることを確認

Generated with [Claude Code](https://claude.ai/code)